### PR TITLE
Add new static `in()` method which accepts an empty header

### DIFF
--- a/src/main/php/webservices/rest/Links.class.php
+++ b/src/main/php/webservices/rest/Links.class.php
@@ -79,18 +79,14 @@ class Links implements Value {
 
   /**
    * Create a Links instance from a header; returning an empty collection if
-   * either `NULL` or an empty string is passed.
+   * `NULL` is passed.
    *
    * @param  ?string $header
    * @return self
    * @throws lang.FormatException If the header is malformed
    */
   public static function in($header) {
-    if (null === $header || '' === $header) {
-      return new self([]);
-    } else {
-      return new self((string)$header);
-    }
+    return new self(null === $header ? [] : (string)$header);
   }
 
   /**

--- a/src/main/php/webservices/rest/Links.class.php
+++ b/src/main/php/webservices/rest/Links.class.php
@@ -33,10 +33,26 @@ class Links implements Value {
   /**
    * Parses a Link header into a links structure
    *
+   * @param  string|webservices.rest.Link[] $arg
+   * @throws lang.FormatException If a string is passed and it's malformed
+   */
+  public function __construct($arg) {
+    if (is_array($arg)) {
+      $this->links= $arg;
+    } else {
+      $this->links= $this->parse($arg);
+    }
+  }
+
+  /**
+   * Parse an input string
+   *
    * @param  string $header
+   * @return webservices.rest.Link[]
    * @throws lang.FormatException If the header is malformed
    */
-  public function __construct($header) {
+  private function parse($header) {
+    $links= [];
     $st= new StringTokenizer($header, '<>', true);
     do {
       $this->expect($st, '<');
@@ -56,8 +72,25 @@ class Links implements Value {
         $params[$param]= $value;
       } while ($st->hasMoreTokens());
 
-      $this->links[]= new Link($uri, $params);
+      $links[]= new Link($uri, $params);
     } while ($st->nextToken('<'));
+    return $links;
+  }
+
+  /**
+   * Create a Links instance from a header; returning an empty collection if
+   * either `NULL` or an empty string is passed.
+   *
+   * @param  ?string $header
+   * @return self
+   * @throws lang.FormatException If the header is malformed
+   */
+  public static function in($header) {
+    if (null === $header || '' === $header) {
+      return new self([]);
+    } else {
+      return new self((string)$header);
+    }
   }
 
   /**

--- a/src/test/php/webservices/rest/unittest/LinksTest.class.php
+++ b/src/test/php/webservices/rest/unittest/LinksTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace webservices\rest\unittest;
 
+use lang\FormatException;
 use webservices\rest\Link;
 use webservices\rest\Links;
-use lang\FormatException;
 
 class LinksTest extends \unittest\TestCase {
 
@@ -19,7 +19,14 @@ class LinksTest extends \unittest\TestCase {
     new Links($header);
   }
 
+  #[@test]
+  public function can_create_from_array() {
+    $list= [new Link('http://example.com/?page=2', ['rel' => 'next'])];
+    $this->assertEquals($list, iterator_to_array((new Links($list))->all()));
+  }
+
   #[@test, @expect(FormatException::class), @values([
+  #  [null],
   #  [''],
   #  ['<>'],
   #  ['<http://example.com/?page=2'],
@@ -40,6 +47,17 @@ class LinksTest extends \unittest\TestCase {
   public function all_with_rel() {
     $links= new Links('<http://example.com/?page=2>; rel="next", <http://example.com/>; title="Home"');
     $this->assertEquals([new Link('http://example.com/?page=2', ['rel' => 'next'])], iterator_to_array($links->all(['rel' => null])));
+  }
+
+  #[@test, @values([null, ''])]
+  public function in($header) {
+    $links= Links::in('<http://example.com/?page=2>; rel="next"');
+    $this->assertEquals([new Link('http://example.com/?page=2', ['rel' => 'next'])], iterator_to_array($links->all()));
+  }
+
+  #[@test, @values([null, ''])]
+  public function in_can_handle_empty($header) {
+    $this->assertEquals([], iterator_to_array(Links::in($header)->all()));
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/LinksTest.class.php
+++ b/src/test/php/webservices/rest/unittest/LinksTest.class.php
@@ -55,9 +55,9 @@ class LinksTest extends \unittest\TestCase {
     $this->assertEquals([new Link('http://example.com/?page=2', ['rel' => 'next'])], iterator_to_array($links->all()));
   }
 
-  #[@test, @values([null, ''])]
-  public function in_can_handle_empty($header) {
-    $this->assertEquals([], iterator_to_array(Links::in($header)->all()));
+  #[@test]
+  public function in_can_handle_empty() {
+    $this->assertEquals([], iterator_to_array(Links::in(null)->all()));
   }
 
   #[@test]


### PR DESCRIPTION
## Before

```php
$resource= 'groups';
do {
  $response= $this->endpoint->resource($resource)->accepting(JSON)->get(['per_page' => 200]);
  foreach ($response->value() as $group) {
    yield $group['id'] => $group
  }

  // The code below here is kind of noisy:
  if (null === ($header= $response->header('Link'))) break;
} while ($resource= (new Links($header))->uri(['rel' => 'next']));
```

## After


```php
$resource= 'groups';
do {
  $response= $this->endpoint->resource($resource)->accepting(JSON)->get(['per_page' => 200]);
  foreach ($response->value() as $group) {
    yield $group['id'] => $group
  }

  // The new code is more concise
} while ($resource= Links::in($response->header('Link')))->uri(['rel' => 'next']));
``` 