### PR TITLE
Cookies

### DIFF
--- a/src/main/php/webservices/rest/Cookie.class.php
+++ b/src/main/php/webservices/rest/Cookie.class.php
@@ -20,6 +20,12 @@ class Cookie implements Value {
     $this->attributes= $attributes;
   }
 
+  /** @return string */
+  public function name() { return $this->name; }
+
+  /** @return string */
+  public function value() { return $this->value; }
+
   /** @return ?util.Date */
   public function expires() { return isset($this->attributes['Expires']) ? new Date($this->attributes['Expires']) : null; }
 

--- a/src/main/php/webservices/rest/Cookie.class.php
+++ b/src/main/php/webservices/rest/Cookie.class.php
@@ -1,16 +1,63 @@
 <?php namespace webservices\rest;
 
-class Cookie {
-  private $name, $value;
-  private $attributes= [];
+use lang\Value;
+use util\Date;
+use util\Objects;
 
-  public function __construct($name, $value) {
+class Cookie implements Value {
+  private $name, $value, $attributes;
+
+  /**
+   * Creates a cookie
+   *
+   * @param  string $name
+   * @param  string $value
+   * @param  [:var] $attributes
+   */
+  public function __construct($name, $value, $attributes= []) {
     $this->name= $name;
     $this->value= $value;
+    $this->attributes= $attributes;
   }
 
-  public function with($name, $value) {
-    $this->attributes[$name]= $value;
-    return $this;
+  /** @return ?util.Date */
+  public function expires() { return isset($this->attributes['Expires']) ? new Date($this->attributes['Expires']) : null; }
+
+  /** @return ?int */
+  public function maxAge() { return isset($this->attributes['Max-Age']) ? (int)$this->attributes['Max-Age'] : null; }
+
+  /** @return ?string */
+  public function domain() { return isset($this->attributes['Domain']) ? (int)$this->attributes['Domain'] : null; }
+
+  /** @return ?string */
+  public function path() { return isset($this->attributes['Path']) ? $this->attributes['Path'] : null; }
+
+  /** @return bool */
+  public function httpOnly() { return isset($this->attributes['HttpOnly']); }
+
+  /** @return bool */
+  public function secure() { return isset($this->attributes['Secure']); }
+
+  /** @return ?string */
+  public function sameSite() { return isset($this->attributes['SameSite']) ? $this->attributes['SameSite'] : null; }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'('.$this->name.'='.$this->value.')@'.Objects::stringOf($this->attributes);
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::stringOf((array)$this);
+  }
+
+  /**
+   * Compares this cookie to another given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare((array)$this, (array)$value) : 1;
   }
 }

--- a/src/main/php/webservices/rest/Cookie.class.php
+++ b/src/main/php/webservices/rest/Cookie.class.php
@@ -33,7 +33,7 @@ class Cookie implements Value {
   public function maxAge() { return isset($this->attributes['Max-Age']) ? (int)$this->attributes['Max-Age'] : null; }
 
   /** @return ?string */
-  public function domain() { return isset($this->attributes['Domain']) ? (int)$this->attributes['Domain'] : null; }
+  public function domain() { return isset($this->attributes['Domain']) ? $this->attributes['Domain'] : null; }
 
   /** @return ?string */
   public function path() { return isset($this->attributes['Path']) ? $this->attributes['Path'] : null; }
@@ -54,7 +54,7 @@ class Cookie implements Value {
 
   /** @return string */
   public function hashCode() {
-    return Objects::stringOf((array)$this);
+    return Objects::hashOf((array)$this);
   }
 
   /**

--- a/src/main/php/webservices/rest/Cookie.class.php
+++ b/src/main/php/webservices/rest/Cookie.class.php
@@ -1,0 +1,16 @@
+<?php namespace webservices\rest;
+
+class Cookie {
+  private $name, $value;
+  private $attributes= [];
+
+  public function __construct($name, $value) {
+    $this->name= $name;
+    $this->value= $value;
+  }
+
+  public function with($name, $value) {
+    $this->attributes[$name]= $value;
+    return $this;
+  }
+}

--- a/src/main/php/webservices/rest/Cookie.class.php
+++ b/src/main/php/webservices/rest/Cookie.class.php
@@ -18,6 +18,11 @@ class Cookie implements Value {
     $this->name= $name;
     $this->value= $value;
     $this->attributes= $attributes;
+
+    // If both (Expires and Max-Age) are set, Max-Age will have precedence.
+    if (isset($this->attributes['Max-Age'])) {
+      $this->attributes['Expires']= gmdate('D, d M Y H:i:s \G\M\T', time() + $this->attributes['Max-Age']);
+    }
   }
 
   /** @return string */

--- a/src/main/php/webservices/rest/Cookie.class.php
+++ b/src/main/php/webservices/rest/Cookie.class.php
@@ -23,7 +23,7 @@ class Cookie implements Value {
   /** @return string */
   public function name() { return $this->name; }
 
-  /** @return string */
+  /** @return ?string */
   public function value() { return $this->value; }
 
   /** @return ?util.Date */

--- a/src/main/php/webservices/rest/Cookies.class.php
+++ b/src/main/php/webservices/rest/Cookies.class.php
@@ -108,7 +108,15 @@ class Cookies implements Value, \IteratorAggregate {
   }
 
   /** @return string */
-  public function toString() { return nameof($this).'@'.Objects::stringOf($this->list); }
+  public function toString() {
+    $s= nameof($this)."@{\n";
+    foreach ($this->list as $lookup) {
+      foreach ($lookup as $cookie) {
+        $s.= '  '.str_replace("\n", "\n  ", $cookie->toString())."\n";
+      }
+    }
+    return $s.'}';
+  }
 
   /** @return string */
   public function hashCode() { return Objects::hashOf($this->list); }

--- a/src/main/php/webservices/rest/Cookies.class.php
+++ b/src/main/php/webservices/rest/Cookies.class.php
@@ -4,6 +4,11 @@ use lang\ElementNotFoundException;
 use lang\Value;
 use util\Objects;
 
+/**
+ * Cookie JAR
+ *
+ * @test  xp://webservices.rest.unittest.CookiesTest
+ */
 class Cookies implements Value, \IteratorAggregate {
   public static $EMPTY;
   private $named= [];

--- a/src/main/php/webservices/rest/Cookies.class.php
+++ b/src/main/php/webservices/rest/Cookies.class.php
@@ -23,7 +23,7 @@ class Cookies implements Value, \IteratorAggregate {
 
   /** @param webservices.rest.Cookie[]|[:?string] $cookies */
   public function __construct($cookies) {
-    $this->merge($cookies);
+    $this->update($cookies);
   }
 
   /**
@@ -88,12 +88,12 @@ class Cookies implements Value, \IteratorAggregate {
   public function clear() { $this->list= []; return $this; }
 
   /**
-   * Merges these cookies with a given list of cookies
+   * Update these cookies with a given list of cookies
    *
    * @param  webservices.rest.Cookie[]|[:?string] $cookies
    * @return self
    */
-  public function merge($cookies) {
+  public function update($cookies) {
     foreach ($cookies as $name => $cookie) {
       if ($cookie instanceof Cookie) {
         $domain= $cookie->domain();

--- a/src/main/php/webservices/rest/Cookies.class.php
+++ b/src/main/php/webservices/rest/Cookies.class.php
@@ -9,7 +9,7 @@ class Cookies implements Value, \IteratorAggregate {
   private $named= [];
 
   static function __static() {
-    self::$EMPTY= new self([]);
+    self::$EMPTY= new self([]);  // @codeCoverageIgnore
   }
 
   /** @param webservices.rest.Cookie[]|[:?string] $cookies */
@@ -53,9 +53,17 @@ class Cookies implements Value, \IteratorAggregate {
   public function merge($cookies) {
     foreach ($cookies as $name => $cookie) {
       if ($cookie instanceof Cookie) {
-        $this->named[$cookie->name()]= $cookie;
+        if (null === ($value= $cookie->value())) {
+          unset($this->named[$cookie->name()]);
+        } else {
+          $this->named[$cookie->name()]= $cookie;
+        }
       } else {
-        $this->named[$name]= new Cookie($name, $cookie);
+        if (null === $cookie) {
+          unset($this->named[$name]);
+        } else {
+          $this->named[$name]= new Cookie($name, $cookie);
+        }
       }
     }
     return $this;

--- a/src/main/php/webservices/rest/Cookies.class.php
+++ b/src/main/php/webservices/rest/Cookies.class.php
@@ -82,13 +82,13 @@ class Cookies implements Value, \IteratorAggregate {
   }
 
   /**
-   * Retrieves cookies for a given URI. 
+   * Retrieves non-expired cookies for a given URI.
    *
    * @param  string|util.URI $arg
    * @param  ?util.Date $rel
    * @return iterable
    */
-  public function forURI($arg, $rel= null) {
+  public function validFor($arg, $rel= null) {
     $uri= $arg instanceof URI ? $arg : new URI($arg);
     $normalized= (string)$uri->canonicalize();
     $rel || $rel= Date::now();

--- a/src/main/php/webservices/rest/Cookies.class.php
+++ b/src/main/php/webservices/rest/Cookies.class.php
@@ -1,0 +1,90 @@
+<?php namespace webservices\rest;
+
+use lang\ElementNotFoundException;
+use lang\Value;
+use util\Objects;
+
+class Cookies implements Value, \IteratorAggregate {
+  public static $EMPTY;
+  private $named= [];
+
+  static function __static() {
+    self::$EMPTY= new self([]);
+  }
+
+  /** @param webservices.rest.Cookie[]|[:?string] $cookies */
+  public function __construct($cookies) {
+    $this->merge($cookies);
+  }
+
+  /** @return bool */
+  public function present() { return sizeof($this->named) > 0; }
+
+  /**
+   * Checks whether a given cookie is contained in this list
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function provides($name) { return isset($this->named[$name]); }
+
+  /**
+   * Returns a given named cookie
+   *
+   * @param  string $name
+   * @return webservices.rest.Cookie
+   * @throws lang.ElementNotFoundException
+   */
+  public function named($name) {
+    if (isset($this->named[$name])) return $this->named[$name];
+
+    throw new ElementNotFoundException('No cookie named "'.$name.'"');
+  }
+
+  /** @return self */
+  public function clear() { $this->named= []; return $this; }
+
+  /**
+   * Merges these cookies with a given list of cookies
+   *
+   * @param  webservices.rest.Cookie[]|[:?string] $cookies
+   * @return self
+   */
+  public function merge($cookies) {
+    foreach ($cookies as $name => $cookie) {
+      if ($cookie instanceof Cookie) {
+        $this->named[$cookie->name()]= $cookie;
+      } else {
+        $this->named[$name]= new Cookie($name, $cookie);
+      }
+    }
+    return $this;
+  }
+
+  /** @return iterable */
+  public function getIterator() {
+    foreach ($this->named as $name => $cookie) {
+      yield $name => $cookie;
+    }
+  }
+
+  /** @return string */
+  public function toString() {
+    return nameof($this).'@'.Objects::stringOf($this->named);
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf($this->named);
+  }
+
+  /**
+   * Compares this cookie to another given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->named, $value->named) : 1;
+  }
+}

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -89,10 +89,15 @@ class Endpoint {
     $uri= $this->base->resolve($request->path());
     $conn= $this->connections->__invoke($uri);
 
+    $headers= $request->headers();
+    // foreach ($request->cookies()->forURI($uri) as $cookie) {
+    //   $headers['Set-Cookie'][]= $cookie->name().'='.urlencode($cookie->value());
+    // }
+
     $s= $conn->create(new HttpRequest());
     $s->setMethod($request->method());
     $s->setTarget($uri->path());
-    $s->addHeaders($request->headers());
+    $s->addHeaders($headers);
     $s->setParameters($request->parameters());
 
     try {

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -90,9 +90,9 @@ class Endpoint {
     $conn= $this->connections->__invoke($uri);
 
     $headers= $request->headers();
-    // foreach ($request->cookies()->forURI($uri) as $cookie) {
-    //   $headers['Set-Cookie'][]= $cookie->name().'='.urlencode($cookie->value());
-    // }
+    foreach ($request->cookies()->forURI($uri) as $cookie) {
+      $headers['Set-Cookie'][]= $cookie->name().'='.urlencode($cookie->value());
+    }
 
     $s= $conn->create(new HttpRequest());
     $s->setMethod($request->method());

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -88,11 +88,15 @@ class Endpoint {
   public function execute(RestRequest $request) {
     $uri= $this->base->resolve($request->path());
     $conn= $this->connections->__invoke($uri);
-
     $headers= $request->headers();
+
+    // RFC 6265: When the user agent generates an HTTP request, the user agent
+    // MUST NOT attach more than one Cookie header field.
+    $cookies= (array)$request->header('Cookie');
     foreach ($request->cookies()->forURI($uri) as $cookie) {
-      $headers['Set-Cookie'][]= $cookie->name().'='.urlencode($cookie->value());
+      $cookies[]= $cookie->name().'='.urlencode($cookie->value());
     }
+    $cookies && $headers['Cookie']= implode('; ', $cookies);
 
     $s= $conn->create(new HttpRequest());
     $s->setMethod($request->method());

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -93,7 +93,7 @@ class Endpoint {
     // RFC 6265: When the user agent generates an HTTP request, the user agent
     // MUST NOT attach more than one Cookie header field.
     $cookies= (array)$request->header('Cookie');
-    foreach ($request->cookies()->forURI($uri) as $cookie) {
+    foreach ($request->cookies()->validFor($uri) as $cookie) {
       $cookies[]= $cookie->name().'='.urlencode($cookie->value());
     }
     $cookies && $headers['Cookie']= implode('; ', $cookies);

--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -8,7 +8,7 @@
 class RestRequest {
   use Headers;
 
-  private $method, $path;
+  private $method, $path, $cookies;
   private $parameters= [];
   private $payload= null;
 
@@ -23,6 +23,7 @@ class RestRequest {
     $this->method= $method;
     $this->path= $path;
     $this->add($headers);
+    $this->cookies= Cookies::$EMPTY;
   }
 
   /** @return string */
@@ -33,6 +34,9 @@ class RestRequest {
 
   /** @return [:string] */
   public function parameters() { return $this->parameters; }
+
+  /** @return webservices.rest.Cookies */
+  public function cookies() { return $this->cookies; }
 
   /** @return webservices.rest.Payload */
   public function payload() { return $this->payload; }
@@ -56,6 +60,17 @@ class RestRequest {
    */
   public function with($headers) {
     $this->add($headers);
+    return $this;
+  }
+
+  /**
+   * Includes given cookies
+   *
+   * @param  [:?string]|webservices.rest.Cookie[]|webservices.rest.Cookies $cookies
+   * @return self
+   */
+  public function including($cookies) {
+    $this->cookies= $cookies instanceof Cookies ? $cookies : new Cookies($cookies);
     return $this;
   }
 

--- a/src/main/php/webservices/rest/RestResource.class.php
+++ b/src/main/php/webservices/rest/RestResource.class.php
@@ -92,6 +92,21 @@ class RestResource {
     return $this;
   }
 
+  /**
+   * Passes given cookies. Encodes value using URL encoding.
+   *
+   * @param  [:?string] $cookies
+   * @return self
+   */
+  public function passing($cookies) {
+    $header= '';
+    foreach ($cookies as $name => $value) {
+      $header.= ', '.$name.'='.urlencode($value);
+    }
+    $this->headers['Cookie'][]= substr($header, 2);
+    return $this;
+  }
+
   public function get($parameters= []) {
     $request= clone $this->request;
     return $this->endpoint->execute($request->using('GET')

--- a/src/main/php/webservices/rest/RestResource.class.php
+++ b/src/main/php/webservices/rest/RestResource.class.php
@@ -102,11 +102,15 @@ class RestResource {
     $header= '';
     if (0 === key($cookies)) {
       foreach ($cookies as $cookie) {
-        $header.= ', '.$cookie->name().'='.urlencode($cookie->value());
+        if (null !== ($value= $cookie->value())) {
+          $header.= ', '.$cookie->name().'='.urlencode($cookie->value());
+        }
       }
     } else {
       foreach ($cookies as $name => $value) {
-        $header.= ', '.$name.'='.urlencode($value);
+        if (null !== $value) {
+          $header.= ', '.$name.'='.urlencode($value);
+        }
       }
     }
     $this->headers['Cookie'][]= substr($header, 2);

--- a/src/main/php/webservices/rest/RestResource.class.php
+++ b/src/main/php/webservices/rest/RestResource.class.php
@@ -95,23 +95,20 @@ class RestResource {
   /**
    * Passes given cookies. Encodes value using URL encoding.
    *
-   * @param  [:?string]|webservices.rest.Cookie[] $cookies
+   * @param  [:?string]|webservices.rest.Cookie[]|webservices.rest.Cookies $cookies
    * @return self
    */
   public function passing($cookies) {
     $header= '';
-    if (0 === key($cookies)) {
-      foreach ($cookies as $cookie) {
-        if (null !== ($value= $cookie->value())) {
-          $header.= ', '.$cookie->name().'='.urlencode($cookie->value());
-        }
+    foreach ($cookies as $name => $cookie) {
+      if ($cookie instanceof Cookie) {
+        $name= $cookie->name();
+        $value= $cookie->value();
+      } else {
+        $value= $cookie;
       }
-    } else {
-      foreach ($cookies as $name => $value) {
-        if (null !== $value) {
-          $header.= ', '.$name.'='.urlencode($value);
-        }
-      }
+
+      null === $value || $header.= ', '.$name.'='.urlencode($value);
     }
     $this->headers['Cookie'][]= substr($header, 2);
     return $this;

--- a/src/main/php/webservices/rest/RestResource.class.php
+++ b/src/main/php/webservices/rest/RestResource.class.php
@@ -95,13 +95,19 @@ class RestResource {
   /**
    * Passes given cookies. Encodes value using URL encoding.
    *
-   * @param  [:?string] $cookies
+   * @param  [:?string]|webservices.rest.Cookie[] $cookies
    * @return self
    */
   public function passing($cookies) {
     $header= '';
-    foreach ($cookies as $name => $value) {
-      $header.= ', '.$name.'='.urlencode($value);
+    if (0 === key($cookies)) {
+      foreach ($cookies as $cookie) {
+        $header.= ', '.$cookie->name().'='.urlencode($cookie->value());
+      }
+    } else {
+      foreach ($cookies as $name => $value) {
+        $header.= ', '.$name.'='.urlencode($value);
+      }
     }
     $this->headers['Cookie'][]= substr($header, 2);
     return $this;

--- a/src/main/php/webservices/rest/RestResource.class.php
+++ b/src/main/php/webservices/rest/RestResource.class.php
@@ -93,24 +93,13 @@ class RestResource {
   }
 
   /**
-   * Passes given cookies. Encodes value using URL encoding.
+   * Includes given cookies. Encodes value using URL encoding.
    *
    * @param  [:?string]|webservices.rest.Cookie[]|webservices.rest.Cookies $cookies
    * @return self
    */
-  public function passing($cookies) {
-    $header= '';
-    foreach ($cookies as $name => $cookie) {
-      if ($cookie instanceof Cookie) {
-        $name= $cookie->name();
-        $value= $cookie->value();
-      } else {
-        $value= $cookie;
-      }
-
-      null === $value || $header.= ', '.$name.'='.urlencode($value);
-    }
-    $this->headers['Cookie'][]= substr($header, 2);
+  public function including($cookies) {
+    $this->request->including($cookies);
     return $this;
   }
 

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -84,7 +84,7 @@ class RestResponse implements Value {
 
         // A cookie belonging to a domain that does not include the origin server 
         // should be rejected by the user agent
-        if ($this->uri && !preg_match('/^.+'.preg_quote($attributes['Domain']).'/', $this->uri->host())) continue;
+        if ($this->uri && !preg_match('/^.+'.preg_quote($attributes['Domain']).'$/', $this->uri->host())) continue;
         $attributes['Domain']= '.'.ltrim($attributes['Domain'], '.');
       } else if ($this->uri) {
         $attributes['Domain']= $this->uri->host();

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -63,6 +63,7 @@ class RestResponse implements Value {
    * However, it does *not* take https://publicsuffix.org/list/ into account!
    *
    * @see    https://tools.ietf.org/html/rfc6265
+   * @see    https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02
    * @return webservices.rest.Cookies
    */
   public function cookies() {
@@ -77,6 +78,13 @@ class RestResponse implements Value {
           $r= sscanf(trim($attribute), "%[^=]=%[^\r]", $name, $value);
           $attr[$name]= 2 === $r ? urldecode($value) : true;
         }
+      }
+
+      if (0 === strncmp($matches[1], '__Host-', 7)) {
+        if (isset($attr['Domain']) || !isset($attr['Path']) || '/' !== $attr['Path']) continue;
+        $name= substr($matches[1], 7);
+      } else {
+        $name= $matches[1];
       }
 
       // Reject cookies if:
@@ -95,7 +103,7 @@ class RestResponse implements Value {
         $attr['Domain']= $this->uri->host();
       }
 
-      $list[]= new Cookie($matches[1], isset($matches[2]) ? urldecode($matches[2]) : null, $attr);
+      $list[]= new Cookie($name, isset($matches[2]) ? urldecode($matches[2]) : null, $attr);
     }
     return new Cookies($list);
   }

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -77,6 +77,15 @@ class RestResponse implements Value {
           $attributes[$name]= 2 === $r ? urldecode($value) : true;
         }
       }
+
+      // Normalize domain: If a domain is specified, subdomains are always included.
+      // Otherwise, defaults to current host; not including subdomains.
+      if (isset($attributes['Domain'])) {
+        $attributes['Domain']= '.'.ltrim($attributes['Domain'], '.');
+      } else if ($this->uri) {
+        $attributes['Domain']= $this->uri->host();
+      }
+
       $list[]= new Cookie($matches[1], isset($matches[2]) ? urldecode($matches[2]) : null, $attributes);
     }
     return new Cookies($list);

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -67,12 +67,19 @@ class RestResponse implements Value {
   public function cookies() {
     if (!isset($this->lookup['set-cookie'])) return [];
 
-    $r= [];
+    $cookies= [];
     foreach ($this->headers[$this->lookup['set-cookie']] as $cookie) {
-      sscanf($cookie, "%[^=]=%[^\r]", $name, $value);
-      $r[$name]= new Cookie($name, $value);
+      $attributes= [];
+      preg_match('/([^=]+)=("([^"]+)"|([^;]+))?(;(.+))*/', $cookie, $matches);
+      if (isset($matches[6])) {
+        foreach (explode(';', $matches[6]) as $attribute) {
+          $r= sscanf(trim($attribute), "%[^=]=%[^\r]", $name, $value);
+          $attributes[$name]= 2 === $r ? urldecode($value) : true;
+        }
+      }
+      $cookies[$matches[1]]= new Cookie($matches[1], isset($matches[2]) ? urldecode($matches[2]) : null, $attributes);
     }
-    return $r;
+    return $cookies;
   }
 
   /**

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -91,6 +91,11 @@ class RestResponse implements Value {
         $attributes['Domain']= $this->uri->host();
       }
 
+      // Insecure sites (http:) can't set cookies with the "secure" directive
+      if (isset($attributes['Secure']) && $this->uri && 'https' !== $this->uri->scheme()) {
+        continue;
+      }
+
       $list[]= new Cookie($matches[1], isset($matches[2]) ? urldecode($matches[2]) : null, $attributes);
     }
     return new Cookies($list);

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -62,12 +62,12 @@ class RestResponse implements Value {
    * Returns cookies sent by server
    *
    * @see    https://tools.ietf.org/html/rfc6265
-   * @return [:webservices.rest.Cookie]
+   * @return webservices.rest.Cookies
    */
   public function cookies() {
-    if (!isset($this->lookup['set-cookie'])) return [];
+    if (!isset($this->lookup['set-cookie'])) return Cookies::$EMPTY;
 
-    $cookies= [];
+    $list= [];
     foreach ($this->headers[$this->lookup['set-cookie']] as $cookie) {
       $attributes= [];
       preg_match('/([^=]+)=("([^"]+)"|([^;]+))?(;(.+))*/', $cookie, $matches);
@@ -77,9 +77,9 @@ class RestResponse implements Value {
           $attributes[$name]= 2 === $r ? urldecode($value) : true;
         }
       }
-      $cookies[$matches[1]]= new Cookie($matches[1], isset($matches[2]) ? urldecode($matches[2]) : null, $attributes);
+      $list[]= new Cookie($matches[1], isset($matches[2]) ? urldecode($matches[2]) : null, $attributes);
     }
-    return $cookies;
+    return new Cookies($list);
   }
 
   /**

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -81,8 +81,11 @@ class RestResponse implements Value {
       }
 
       if (0 === strncmp($matches[1], '__Host-', 7)) {
-        if (isset($attr['Domain']) || !isset($attr['Path']) || '/' !== $attr['Path']) continue;
+        if (isset($attr['Domain']) || !isset($attr['Path']) || '/' !== $attr['Path'] || !isset($attr['Secure'])) continue;
         $name= substr($matches[1], 7);
+      } else if (0 === strncmp($matches[1], '__Secure-', 9)) {
+        if (!isset($attr['Secure'])) continue;
+        $name= substr($matches[1], 9);
       } else {
         $name= $matches[1];
       }

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -59,7 +59,8 @@ class RestResponse implements Value {
   }
 
   /**
-   * Returns cookies sent by server
+   * Returns cookies sent by server; rejecting cookies from invalid domains.
+   * However, it does *not* take https://publicsuffix.org/list/ into account!
    *
    * @see    https://tools.ietf.org/html/rfc6265
    * @return webservices.rest.Cookies
@@ -83,7 +84,7 @@ class RestResponse implements Value {
       if (isset($attributes['Domain'])) {
 
         // A cookie belonging to a domain that does not include the origin server 
-        // should be rejected by the user agent
+        // should be rejected by the user agent.
         if ($this->uri && !preg_match('/^.+'.preg_quote($attributes['Domain']).'$/', $this->uri->host())) continue;
         $attributes['Domain']= '.'.ltrim($attributes['Domain'], '.');
       } else if ($this->uri) {

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -80,8 +80,11 @@ class RestResponse implements Value {
         }
       }
 
+      // Cookies names with the prefixes __Secure- and __Host- can be used only if they are
+      // set with the secure directive. In addition, cookies with the __Host-prefix must have
+      // a path of "/" (the entire host) and must not have a domain attribute
       if (0 === strncmp($matches[1], '__Host-', 7)) {
-        if (isset($attr['Domain']) || !isset($attr['Path']) || '/' !== $attr['Path'] || !isset($attr['Secure'])) continue;
+        if (!isset($attr['Secure']) || !isset($attr['Path']) || '/' !== $attr['Path'] || isset($attr['Domain'])) continue;
         $name= substr($matches[1], 7);
       } else if (0 === strncmp($matches[1], '__Secure-', 9)) {
         if (!isset($attr['Secure'])) continue;

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -59,6 +59,23 @@ class RestResponse implements Value {
   }
 
   /**
+   * Returns cookies sent by server
+   *
+   * @see    https://tools.ietf.org/html/rfc6265
+   * @return [:webservices.rest.Cookie]
+   */
+  public function cookies() {
+    if (!isset($this->lookup['set-cookie'])) return [];
+
+    $r= [];
+    foreach ($this->headers[$this->lookup['set-cookie']] as $cookie) {
+      sscanf($cookie, "%[^=]=%[^\r]", $name, $value);
+      $r[$name]= new Cookie($name, $value);
+    }
+    return $r;
+  }
+
+  /**
    * Returns a value from the response, using the given type for deserialization
    *
    * @param  string $type

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -81,6 +81,10 @@ class RestResponse implements Value {
       // Normalize domain: If a domain is specified, subdomains are always included.
       // Otherwise, defaults to current host; not including subdomains.
       if (isset($attributes['Domain'])) {
+
+        // A cookie belonging to a domain that does not include the origin server 
+        // should be rejected by the user agent
+        if ($this->uri && !preg_match('/^.+'.preg_quote($attributes['Domain']).'/', $this->uri->host())) continue;
         $attributes['Domain']= '.'.ltrim($attributes['Domain'], '.');
       } else if ($this->uri) {
         $attributes['Domain']= $this->uri->host();

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -55,7 +55,7 @@ class CookiesTest extends TestCase {
     ];
 
     $cookies= new Cookies(array_merge($excluded, $included));
-    $this->assertEquals($included, iterator_to_array($cookies->forURI('http://sub.example.com/path')));
+    $this->assertEquals($included, iterator_to_array($cookies->validFor('http://sub.example.com/path')));
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -38,6 +38,7 @@ class CookiesTest extends TestCase {
 
   #[@test]
   public function for_domain_and_path() {
+    $expired= gmdate('D, d M Y H:i:s \G\M\T', time() - 86400);
     $included= [
       new Cookie('session', '0x6100', ['Domain' => 'sub.example.com', 'Path' => '/path']),
       new Cookie('lang', 'de', ['Domain' => '.example.com', 'Path' => '/path']),
@@ -45,6 +46,7 @@ class CookiesTest extends TestCase {
     ];
     $excluded= [
       new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/path']),
+      new Cookie('uid', '1549', ['Domain' => '.example.com', 'Expires' => $expired]),
       new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/other']),
       new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/', 'Secure' => true]),
       new Cookie('session', '0x6100', ['Domain' => 'example.com', 'Path' => '/']),

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -64,7 +64,7 @@ class CookiesTest extends TestCase {
     $cookies= new Cookies(['session' => '0x6100']);
     $this->assertEquals(
       [new Cookie('session', '0x6200')],
-      iterator_to_array($cookies->merge(['session' => '0x6200']))
+      iterator_to_array($cookies->update(['session' => '0x6200']))
     );
   }
 
@@ -73,7 +73,7 @@ class CookiesTest extends TestCase {
     $cookies= new Cookies(['session' => '0x6100', 'lang' => 'de']);
     $this->assertEquals(
       [new Cookie('lang', 'de')],
-      iterator_to_array($cookies->merge(['session' => null]))
+      iterator_to_array($cookies->update(['session' => null]))
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\ElementNotFoundException;
 use unittest\TestCase;
+use unittest\actions\RuntimeVersion;
 use webservices\rest\Cookie;
 use webservices\rest\Cookies;
 
@@ -76,7 +77,7 @@ class CookiesTest extends TestCase {
     );
   }
 
-  #[@test]
+  #[@test, @action(new RuntimeVersion('>=7.0'))]
   public function string_representation() {
     $cookies= new Cookies([
       new Cookie('session', '0x6100', ['Secure' => true]),

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -47,6 +47,7 @@ class CookiesTest extends TestCase {
     $excluded= [
       new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/path']),
       new Cookie('uid', '1549', ['Domain' => '.example.com', 'Expires' => $expired]),
+      new Cookie('accept', 'yes', ['Domain' => '.example.com', 'Max-Age' => 0]),
       new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/other']),
       new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/', 'Secure' => true]),
       new Cookie('session', '0x6100', ['Domain' => 'example.com', 'Path' => '/']),

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -75,4 +75,22 @@ class CookiesTest extends TestCase {
       iterator_to_array($cookies->merge(['session' => null]))
     );
   }
+
+  #[@test]
+  public function string_representation() {
+    $cookies= new Cookies([
+      new Cookie('session', '0x6100', ['Secure' => true]),
+      new Cookie('lang', 'de'),
+    ]);
+
+    $this->assertEquals(
+      "webservices.rest.Cookies@{\n".
+      "  webservices.rest.Cookie(lang=de)@[]\n".
+      "  webservices.rest.Cookie(session=0x6100)@[\n".
+      "    Secure => true\n".
+      "  ]\n".
+      "}",
+      $cookies->toString()
+    );
+  }
 }

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -31,41 +31,35 @@ class CookiesTest extends TestCase {
   }
 
   #[@test]
-  public function named() {
-    $cookies= new Cookies(['session' => '0x6100']);
-    $this->assertEquals('0x6100', $cookies->named('session')->value());
-  }
-
-  #[@test, @expect(ElementNotFoundException::class)]
-  public function named_raises_exception_when_not_existant() {
-    Cookies::$EMPTY->named('session');
-  }
-
-  #[@test]
-  public function provides() {
-    $cookies= new Cookies(['session' => '0x6100']);
-    $this->assertTrue($cookies->provides('session'));
-  }
-
-  #[@test]
-  public function does_not_provide_non_existant() {
-    $this->assertFalse(Cookies::$EMPTY->provides('session'));
-  }
-
-  #[@test]
   public function can_be_iterated() {
     $cookies= new Cookies(['session' => '0x6100']);
-    $this->assertEquals(
-      ['session' => new Cookie('session', '0x6100')],
-      iterator_to_array($cookies)
-    );
+    $this->assertEquals([new Cookie('session', '0x6100')], iterator_to_array($cookies));
+  }
+
+  #[@test]
+  public function for_domain_and_path() {
+    $included= [
+      new Cookie('session', '0x6100', ['Domain' => 'sub.example.com', 'Path' => '/path']),
+      new Cookie('lang', 'de', ['Domain' => '.example.com', 'Path' => '/path']),
+      new Cookie('cookies', 'true', ['Domain' => '.example.com', 'Path' => '/']),
+    ];
+    $excluded= [
+      new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/path']),
+      new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/other']),
+      new Cookie('session', '0x6100', ['Domain' => '.example.com', 'Path' => '/', 'Secure' => true]),
+      new Cookie('session', '0x6100', ['Domain' => 'example.com', 'Path' => '/']),
+      new Cookie('session', '0x6100', ['Domain' => 'other.com', 'Path' => '/']),
+    ];
+
+    $cookies= new Cookies(array_merge($excluded, $included));
+    $this->assertEquals($included, iterator_to_array($cookies->forURI('http://sub.example.com/path')));
   }
 
   #[@test]
   public function cookies_with_same_name_overwritten_during_merge() {
     $cookies= new Cookies(['session' => '0x6100']);
     $this->assertEquals(
-      ['session' => new Cookie('session', '0x6200')],
+      [new Cookie('session', '0x6200')],
       iterator_to_array($cookies->merge(['session' => '0x6200']))
     );
   }
@@ -74,7 +68,7 @@ class CookiesTest extends TestCase {
   public function cookies_without_value_erased() {
     $cookies= new Cookies(['session' => '0x6100', 'lang' => 'de']);
     $this->assertEquals(
-      ['lang' => new Cookie('lang', 'de')],
+      [new Cookie('lang', 'de')],
       iterator_to_array($cookies->merge(['session' => null]))
     );
   }

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -1,0 +1,81 @@
+<?php namespace webservices\rest\unittest;
+
+use lang\ElementNotFoundException;
+use unittest\TestCase;
+use webservices\rest\Cookie;
+use webservices\rest\Cookies;
+
+class CookiesTest extends TestCase {
+
+  #[@test]
+  public function can_create_from_empty() {
+    new Cookies([]);
+  }
+
+  #[@test]
+  public function present() {
+    $cookies= new Cookies(['session' => '0x6100']);
+    $this->assertTrue($cookies->present());
+  }
+
+  #[@test]
+  public function not_present() {
+    $cookies= Cookies::$EMPTY;
+    $this->assertFalse($cookies->present());
+  }
+
+  #[@test]
+  public function no_longer_present_after_clearing() {
+    $cookies= new Cookies(['session' => '0x6100']);
+    $this->assertFalse($cookies->clear()->present());
+  }
+
+  #[@test]
+  public function named() {
+    $cookies= new Cookies(['session' => '0x6100']);
+    $this->assertEquals('0x6100', $cookies->named('session')->value());
+  }
+
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function named_raises_exception_when_not_existant() {
+    Cookies::$EMPTY->named('session');
+  }
+
+  #[@test]
+  public function provides() {
+    $cookies= new Cookies(['session' => '0x6100']);
+    $this->assertTrue($cookies->provides('session'));
+  }
+
+  #[@test]
+  public function does_not_provide_non_existant() {
+    $this->assertFalse(Cookies::$EMPTY->provides('session'));
+  }
+
+  #[@test]
+  public function can_be_iterated() {
+    $cookies= new Cookies(['session' => '0x6100']);
+    $this->assertEquals(
+      ['session' => new Cookie('session', '0x6100')],
+      iterator_to_array($cookies)
+    );
+  }
+
+  #[@test]
+  public function cookies_with_same_name_overwritten_during_merge() {
+    $cookies= new Cookies(['session' => '0x6100']);
+    $this->assertEquals(
+      ['session' => new Cookie('session', '0x6200')],
+      iterator_to_array($cookies->merge(['session' => '0x6200']))
+    );
+  }
+
+  #[@test]
+  public function cookies_without_value_erased() {
+    $cookies= new Cookies(['session' => '0x6100', 'lang' => 'de']);
+    $this->assertEquals(
+      ['lang' => new Cookie('lang', 'de')],
+      iterator_to_array($cookies->merge(['session' => null]))
+    );
+  }
+}

--- a/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
@@ -11,8 +11,11 @@ class ExecuteTest extends TestCase {
   public function get() {
     $fixture= (new Endpoint('http://test'))->connecting(function($uri) { return new TestConnection($uri); });
 
-    $response= $fixture->resource('/test')->get();
-    $this->assertEquals("GET /test HTTP/1.1\r\nConnection: close\r\nHost: test\r\n\r\n", $response->content());
+    $response= $fixture->resource('/test');
+    $this->assertEquals(
+      "GET /test HTTP/1.1\r\nConnection: close\r\nHost: test\r\n\r\n",
+      $response->get()->content()
+    );
   }
 
   #[@test]
@@ -27,7 +30,32 @@ class ExecuteTest extends TestCase {
   public function get_with_parameters_in_resource() {
     $fixture= (new Endpoint('http://test'))->connecting(function($uri) { return new TestConnection($uri); });
 
-    $response= $fixture->resource('/?username={0}', ['test'])->get();
-    $this->assertEquals("GET /?username=test HTTP/1.1\r\nConnection: close\r\nHost: test\r\n\r\n", $response->content());
+    $resource= $fixture->resource('/?username={0}', ['test']);
+    $this->assertEquals(
+      "GET /?username=test HTTP/1.1\r\nConnection: close\r\nHost: test\r\n\r\n",
+      $resource->get()->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_cookies() {
+    $fixture= (new Endpoint('http://test'))->connecting(function($uri) { return new TestConnection($uri); });
+
+    $resource= $fixture->resource('/')->including(['session' => '0x6100', 'lang' => 'de']);
+    $this->assertEquals(
+      "GET / HTTP/1.1\r\nConnection: close\r\nHost: test\r\nCookie: session=0x6100; lang=de\r\n\r\n",
+      $resource->get()->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_cookies_merges_cookie_header() {
+    $fixture= (new Endpoint('http://test'))->connecting(function($uri) { return new TestConnection($uri); });
+
+    $resource= $fixture->resource('/')->with(['Cookie' => 'session=0x6100'])->including(['lang' => 'de']);
+    $this->assertEquals(
+      "GET / HTTP/1.1\r\nConnection: close\r\nHost: test\r\nCookie: session=0x6100; lang=de\r\n\r\n",
+      $resource->get()->content()
+    );
   }
 }

--- a/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
@@ -104,4 +104,15 @@ class RestResourceTest extends TestCase {
       $this->endpoint->sent
     );
   }
+
+  #[@test]
+  public function passing_cookies() {
+    $resource= new RestResource($this->endpoint, '/users');
+    $resource->passing(['lang' => 'de', 'uid' => 6100])->get();
+
+    $this->assertEquals(
+      [(new RestRequest('GET', '/users'))->with(['Cookie' => 'lang=de, uid=6100'])],
+      $this->endpoint->sent
+    );
+  }
 }

--- a/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
@@ -3,6 +3,7 @@
 use lang\ElementNotFoundException;
 use unittest\TestCase;
 use webservices\rest\Cookie;
+use webservices\rest\Cookies;
 use webservices\rest\Endpoint;
 use webservices\rest\RestRequest;
 use webservices\rest\RestResource;
@@ -106,21 +107,15 @@ class RestResourceTest extends TestCase {
     );
   }
 
-  #[@test]
-  public function passing_cookies_as_map() {
+  #[@test, @values([
+  #  [['lang' => 'de', 'uid' => 6100, 'not-sent' => null]],
+  #  [[new Cookie('lang', 'de'), new Cookie('uid',  6100), new Cookie('not-sent', null)]],
+  #  [new Cookies(['lang' => 'de', 'uid' => 6100, 'not-sent' => null])],
+  #  [new Cookies([new Cookie('lang', 'de'), new Cookie('uid',  6100), new Cookie('not-sent', null)])],
+  #])]
+  public function passing_cookies($cookies) {
     $resource= new RestResource($this->endpoint, '/users');
-    $resource->passing(['lang' => 'de', 'uid' => 6100, 'not-sent' => null])->get();
-
-    $this->assertEquals(
-      [(new RestRequest('GET', '/users'))->with(['Cookie' => 'lang=de, uid=6100'])],
-      $this->endpoint->sent
-    );
-  }
-
-  #[@test]
-  public function passing_cookies() {
-    $resource= new RestResource($this->endpoint, '/users');
-    $resource->passing([new Cookie('lang', 'de'), new Cookie('uid',  6100), new Cookie('not-sent', null)])->get();
+    $resource->passing($cookies)->get();
 
     $this->assertEquals(
       [(new RestRequest('GET', '/users'))->with(['Cookie' => 'lang=de, uid=6100'])],

--- a/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
@@ -109,7 +109,7 @@ class RestResourceTest extends TestCase {
   #[@test]
   public function passing_cookies_as_map() {
     $resource= new RestResource($this->endpoint, '/users');
-    $resource->passing(['lang' => 'de', 'uid' => 6100])->get();
+    $resource->passing(['lang' => 'de', 'uid' => 6100, 'not-sent' => null])->get();
 
     $this->assertEquals(
       [(new RestRequest('GET', '/users'))->with(['Cookie' => 'lang=de, uid=6100'])],
@@ -120,7 +120,7 @@ class RestResourceTest extends TestCase {
   #[@test]
   public function passing_cookies() {
     $resource= new RestResource($this->endpoint, '/users');
-    $resource->passing([new Cookie('lang', 'de'), new Cookie('uid',  6100)])->get();
+    $resource->passing([new Cookie('lang', 'de'), new Cookie('uid',  6100), new Cookie('not-sent', null)])->get();
 
     $this->assertEquals(
       [(new RestRequest('GET', '/users'))->with(['Cookie' => 'lang=de, uid=6100'])],

--- a/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\ElementNotFoundException;
 use unittest\TestCase;
+use webservices\rest\Cookie;
 use webservices\rest\Endpoint;
 use webservices\rest\RestRequest;
 use webservices\rest\RestResource;
@@ -106,9 +107,20 @@ class RestResourceTest extends TestCase {
   }
 
   #[@test]
-  public function passing_cookies() {
+  public function passing_cookies_as_map() {
     $resource= new RestResource($this->endpoint, '/users');
     $resource->passing(['lang' => 'de', 'uid' => 6100])->get();
+
+    $this->assertEquals(
+      [(new RestRequest('GET', '/users'))->with(['Cookie' => 'lang=de, uid=6100'])],
+      $this->endpoint->sent
+    );
+  }
+
+  #[@test]
+  public function passing_cookies() {
+    $resource= new RestResource($this->endpoint, '/users');
+    $resource->passing([new Cookie('lang', 'de'), new Cookie('uid',  6100)])->get();
 
     $this->assertEquals(
       [(new RestRequest('GET', '/users'))->with(['Cookie' => 'lang=de, uid=6100'])],

--- a/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
@@ -113,12 +113,12 @@ class RestResourceTest extends TestCase {
   #  [new Cookies(['lang' => 'de', 'uid' => 6100, 'not-sent' => null])],
   #  [new Cookies([new Cookie('lang', 'de'), new Cookie('uid',  6100), new Cookie('not-sent', null)])],
   #])]
-  public function passing_cookies($cookies) {
+  public function including_cookies($cookies) {
     $resource= new RestResource($this->endpoint, '/users');
-    $resource->passing($cookies)->get();
+    $resource->including($cookies)->get();
 
     $this->assertEquals(
-      [(new RestRequest('GET', '/users'))->with(['Cookie' => 'lang=de, uid=6100'])],
+      [(new RestRequest('GET', '/users'))->including($cookies)],
       $this->endpoint->sent
     );
   }

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -108,15 +108,18 @@ class RestResponseTest extends TestCase {
 
   #[@test]
   public function one_cookie() {
-    $headers= ['Set-Cookie' => 'session=0x6100'];
-    $this->assertEquals(['session' => new Cookie('session', '0x6100')], (new RestResponse(200, 'OK', $headers))->cookies());
+    $headers= ['Set-Cookie' => 'session=0x6100; HttpOnly; Path=/'];
+    $this->assertEquals(
+      ['session' => new Cookie('session', '0x6100', ['HttpOnly' => true, 'Path' => '/'])],
+      (new RestResponse(200, 'OK', $headers))->cookies()
+    );
   }
 
   #[@test]
   public function multiple_cookies() {
-    $headers= ['Set-Cookie' => ['session=0x6100', 'language=de']];
+    $headers= ['Set-Cookie' => ['session=0x6100', 'lang=de', 'test=']];
     $this->assertEquals(
-      ['session' => new Cookie('session', '0x6100'), 'language' => new Cookie('language', 'de')],
+      ['session' => new Cookie('session', '0x6100'), 'lang' => new Cookie('lang', 'de'), 'test' => new Cookie('test', null)],
       (new RestResponse(200, 'OK', $headers))->cookies()
     );
   }

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -124,7 +124,7 @@ class RestResponseTest extends TestCase {
   public function multiple_cookies() {
     $headers= ['Set-Cookie' => ['session=0x6100; Max-Age=3600', 'lang=de; Secure', 'test=']];
     $named= [
-      'session' => new Cookie('session', '0x6100', ['Max-Age' => 3600]),
+      'session' => new Cookie('session', '0x6100', ['Max-Age' => '3600']),
       'lang'    => new Cookie('lang', 'de', ['Secure' => true]),
       'test'    => new Cookie('test', null)
     ];

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -132,9 +132,16 @@ class RestResponseTest extends TestCase {
     $this->assertEquals(new Cookies($list), (new RestResponse(200, 'OK', $headers))->cookies());
   }
 
-  #[@test]
-  public function cookie_from_invalid_domain_rejected() {
-    $headers= ['Set-Cookie' => 'session=0x6100; Domain=evil.example.com'];
+  #[@test, @values([
+  #  'evil.example.com',
+  #  'evil.example',
+  #  'example',
+  #  'example.tld',
+  #  'evil-example.com',
+  #  'evil.example.com.tld',
+  #])]
+  public function cookie_from_invalid_domain_rejected($domain) {
+    $headers= ['Set-Cookie' => 'session=0x6100; Domain='.$domain];
     $uri= new URI('http://app.example.com/');
 
     $this->assertEquals(Cookies::$EMPTY, (new RestResponse(200, 'OK', $headers, null, $uri))->cookies());

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -155,4 +155,12 @@ class RestResponseTest extends TestCase {
 
     $this->assertEquals(new Cookies($list), (new RestResponse(200, 'OK', $headers, null, $uri))->cookies());
   }
+
+  #[@test]
+  public function secure_cookies_cannot_be_set_by_inssecure_sites() {
+    $headers= ['Set-Cookie' => 'session=0x6100; Secure'];
+    $uri= new URI('http://app.example.com/');
+
+    $this->assertEquals(Cookies::$EMPTY, (new RestResponse(200, 'OK', $headers, null, $uri))->cookies());
+  }
 }

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -165,6 +165,21 @@ class RestResponseTest extends TestCase {
   }
 
   #[@test]
+  public function secure_prefix() {
+    $headers= ['Set-Cookie' => '__Secure-SID=12345; Secure'];
+    $list= [new Cookie('SID', '12345', ['Secure' => true])];
+
+    $this->assertEquals(new Cookies($list), (new RestResponse(200, 'OK', $headers))->cookies());
+  }
+
+  #[@test]
+  public function secure_prefix_rejects_insecure_cookies() {
+    $headers= ['Set-Cookie' => '__Secure-SID=12345'];
+
+    $this->assertEquals(Cookies::$EMPTY, (new RestResponse(200, 'OK', $headers))->cookies());
+  }
+
+  #[@test]
   public function host_prefix() {
     $headers= ['Set-Cookie' => '__Host-SID=12345; Secure; Path=/'];
     $list= [new Cookie('SID', '12345', ['Domain' => 'app.example.com', 'Path' => '/', 'Secure' => true])];

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -5,6 +5,7 @@ use lang\IllegalStateException;
 use unittest\TestCase;
 use util\URI;
 use util\data\Marshalling;
+use webservices\rest\Cookie;
 use webservices\rest\RestResponse;
 use webservices\rest\format\Json;
 use webservices\rest\io\Reader;
@@ -103,5 +104,20 @@ class RestResponseTest extends TestCase {
     $stream= new MemoryInputStream('{"key":200}');
     $reader= new Reader($stream, new Json(), new Marshalling());
     $this->assertEquals(['key' => '200'], (new RestResponse(200, 'OK', [], $reader))->value('[:string]'));
+  }
+
+  #[@test]
+  public function one_cookie() {
+    $headers= ['Set-Cookie' => 'session=0x6100'];
+    $this->assertEquals(['session' => new Cookie('session', '0x6100')], (new RestResponse(200, 'OK', $headers))->cookies());
+  }
+
+  #[@test]
+  public function multiple_cookies() {
+    $headers= ['Set-Cookie' => ['session=0x6100', 'language=de']];
+    $this->assertEquals(
+      ['session' => new Cookie('session', '0x6100'), 'language' => new Cookie('language', 'de')],
+      (new RestResponse(200, 'OK', $headers))->cookies()
+    );
   }
 }


### PR DESCRIPTION
This pull request implements #3 and adds cookie handling

## Request

Use the `including()` method for REST resources:

```php
$res= $endpoint->resource('search')->including(['lang' => 'de'])->get();
```

## Response

Use the `cookies()` method to retrieve cookies

```php
foreach ($res->cookies() as $name => $cookie) {
  Console::writeLine($name, ' => ', $cookie->value());
}
```

## Cookie JAR

The `cookies()` method returns a `Cookies` instance (and `including()` also accepts it). With this in place, you can implement a simple cookie JAR:

```php
// Initialize cookies with an empty list
$cookies= Cookies::$EMPTY;

// Pass it to resources
$res= $endpoint->resource('search')->including($cookies)->get();

// Update with received cookies
$cookies->update($res->cookies());
```