### PR TITLE
Logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0",
     "xp-framework/http": "^9.1",
+    "xp-framework/logging": "^9.0",
     "xp-framework/tokenize": "^8.0",
     "xp-forge/json": "^3.1",
     "xp-forge/uri": "^1.3",

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -122,16 +122,10 @@ class Endpoint implements Traceable {
     $s->setParameters($request->parameters());
 
     try {
-      if ($payload= $request->payload()) {
-        $input= $this->formats->named($request->header('Content-Type'));
-        $writer= $this->transfer->writer($s, $payload->value(), $input, $this->marshalling);
-        $stream= $writer($conn->open($s));
-      } else {
-        $this->transfer->header($s);
-        $stream= $conn->open($s);
-      }
+      $input= $this->formats->named($request->header('Content-Type'));
+      $writer= $this->transfer->writer($s, $request->payload(), $input, $this->marshalling);
+      $r= $writer($conn);
 
-      $r= $conn->finish($stream);
       $output= $this->formats->named(current($r->header('Content-Type')));
       $reader= $this->transfer->reader($r, $output, $this->marshalling);
       return new RestResponse($r->statusCode(), $r->message(), $r->headers(), $reader, $uri);

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -5,6 +5,7 @@ use peer\http\HttpConnection;
 use peer\http\HttpRequest;
 use util\URI;
 use util\data\Marshalling;
+use util\log\Traceable;
 use webservices\rest\io\Buffered;
 use webservices\rest\io\Reader;
 use webservices\rest\io\Streamed;
@@ -14,8 +15,9 @@ use webservices\rest\io\Streamed;
  *
  * @test  xp://web.rest.unittest.EndpointTest
  */
-class Endpoint {
+class Endpoint implements Traceable {
   private $base, $formats, $transfer, $marshalling;
+  private $cat= null;
 
   /**
    * Creates a new REST endpoint with a given base URI. The base URI may contain
@@ -79,6 +81,16 @@ class Endpoint {
   }
 
   /**
+   * Sets a log category for debugging
+   *
+   * @param  ?util.log.LogCategory $cat
+   * @return void
+   */
+  public function setTrace($cat) {
+    $this->cat= $cat;
+  }
+
+  /**
    * Sends a request and returns the response
    *
    * @param  web.rest.RestRequest $request
@@ -88,6 +100,7 @@ class Endpoint {
   public function execute(RestRequest $request) {
     $uri= $this->base->resolve($request->path());
     $conn= $this->connections->__invoke($uri);
+    $conn->setTrace($this->cat);
     $headers= $request->headers();
 
     // RFC 6265: When the user agent generates an HTTP request, the user agent

--- a/src/main/php/webservices/rest/io/Buffered.class.php
+++ b/src/main/php/webservices/rest/io/Buffered.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\MemoryOutputStream;
 
-class Buffered implements Transfer {
+class Buffered extends Transfer {
 
   public function writer($request, $payload, $format, $marshalling) {
     $bytes= $format->serialize($marshalling->marshal($payload), new MemoryOutputStream())->getBytes();

--- a/src/main/php/webservices/rest/io/Buffered.class.php
+++ b/src/main/php/webservices/rest/io/Buffered.class.php
@@ -4,12 +4,13 @@ use io\streams\MemoryOutputStream;
 
 class Buffered extends Transfer {
 
-  public function writer($request, $payload, $format, $marshalling) {
+  protected function payload($request, $payload, $format, $marshalling) {
     $bytes= $format->serialize($marshalling->marshal($payload), new MemoryOutputStream())->getBytes();
     $request->setHeader('Content-Length', strlen($bytes));
-    return function($stream) use($bytes) {
+    return function($conn) use($request, $bytes) {
+      $stream= $conn->open($request);
       $stream->write($bytes);
-      return $stream;
+      return $conn->finish($stream);
     };
   }
 }

--- a/src/main/php/webservices/rest/io/Streamed.class.php
+++ b/src/main/php/webservices/rest/io/Streamed.class.php
@@ -1,6 +1,6 @@
 <?php namespace webservices\rest\io;
 
-class Streamed implements Transfer {
+class Streamed extends Transfer {
 
   public function writer($request, $payload, $format, $marshalling) {
     $request->setHeader('Transfer-Encoding', 'chunked');

--- a/src/main/php/webservices/rest/io/Streamed.class.php
+++ b/src/main/php/webservices/rest/io/Streamed.class.php
@@ -2,10 +2,12 @@
 
 class Streamed extends Transfer {
 
-  public function writer($request, $payload, $format, $marshalling) {
+  protected function payload($request, $payload, $format, $marshalling) {
     $request->setHeader('Transfer-Encoding', 'chunked');
-    return function($stream) use($payload, $format, $marshalling) {
-      return $format->serialize($marshalling->marshal($payload), $stream);
+    return function($conn) use($request, $payload, $format, $marshalling) {
+      $stream= $conn->open($request);
+      $format->serialize($marshalling->marshal($payload), $stream);
+      return $conn->finish($stream);
     };
   }
 }

--- a/src/main/php/webservices/rest/io/Traced.class.php
+++ b/src/main/php/webservices/rest/io/Traced.class.php
@@ -1,0 +1,48 @@
+<?php namespace webservices\rest\io;
+
+use io\streams\MemoryInputStream;
+use io\streams\MemoryOutputStream;
+use io\streams\Streams;
+
+class Traced extends Transfer {
+  private $untraced, $cat;
+
+  /**
+   * Created a new traced transfer
+   *
+   * @param  parent $untraced
+   * @param  util.log.LogCategory $cat
+   */
+  public function __construct($untraced, $cat) {
+    $this->untraced= $untraced;
+    $this->cat= $cat;
+  }
+
+  /** @return parent */
+  public function untraced() { return $this->untraced; }
+
+  public function header($request) {
+    $this->cat->info('>>>', substr($request->getHeaderString(), 0, -2));
+  }
+
+  public function writer($request, $payload, $format, $marshalling) {
+    $this->cat->info('>>>', substr($request->getHeaderString(), 0, -2));
+    $bytes= $format->serialize($marshalling->marshal($payload), new MemoryOutputStream())->getBytes();
+    $this->cat->debug($bytes);
+
+    // We've created it anyway, now simply transfer the bytes in a buffered manner
+    $request->setHeader('Content-Length', strlen($bytes));
+    return function($stream) use($bytes) {
+      $stream->write($bytes);
+      return $stream;
+    };
+  }
+
+  public function reader($response, $format, $marshalling) {
+    $this->cat->info('<<<', substr($response->getHeaderString(), 0, -2));
+    $bytes= Streams::readAll($response->in());
+    $this->cat->debug($bytes);
+
+    return new Reader(new MemoryInputStream($bytes), $format, $marshalling);
+  }
+}

--- a/src/main/php/webservices/rest/io/Transfer.class.php
+++ b/src/main/php/webservices/rest/io/Transfer.class.php
@@ -1,15 +1,23 @@
 <?php namespace webservices\rest\io;
 
+use lang\MethodNotImplementedException;
+
 abstract class Transfer {
 
   /** @return self */
   public function untraced() { return $this; }
 
-  public function header($request) {
-    // NOOP
+  protected function payload($request, $value, $format, $marshalling) {
+    throw new MethodNotImplementedException('payload()');
   }
 
-  public abstract function writer($request, $payload, $format, $marshalling);
+  public function writer($request, $payload, $format, $marshalling) {
+    if ($payload) {
+      return $this->payload($request, $payload->value(), $format, $marshalling);
+    } else {
+      return function($conn) use($request) { return $conn->send($request); };
+    }
+  }
 
   public function reader($response, $format, $marshalling) {
     return new Reader($response->in(), $format, $marshalling);

--- a/src/main/php/webservices/rest/io/Transfer.class.php
+++ b/src/main/php/webservices/rest/io/Transfer.class.php
@@ -1,6 +1,17 @@
 <?php namespace webservices\rest\io;
 
-interface Transfer {
+abstract class Transfer {
 
-  public function writer($request, $payload, $format, $marshalling);
+  /** @return self */
+  public function untraced() { return $this; }
+
+  public function header($request) {
+    // NOOP
+  }
+
+  public abstract function writer($request, $payload, $format, $marshalling);
+
+  public function reader($response, $format, $marshalling) {
+    return new Reader($response->in(), $format, $marshalling);
+  }
 }

--- a/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
@@ -13,10 +13,10 @@ class ExecuteTest extends TestCase {
   public function get() {
     $fixture= (new Endpoint('http://test'))->connecting(function($uri) { return new TestConnection($uri); });
 
-    $response= $fixture->resource('/test');
+    $response= $fixture->resource('/test')->get();
     $this->assertEquals(
       "GET /test HTTP/1.1\r\nConnection: close\r\nHost: test\r\n\r\n",
-      $response->get()->content()
+      $response->content()
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
@@ -3,6 +3,8 @@
 use lang\ClassLoader;
 use peer\http\HttpConnection;
 use unittest\TestCase;
+use util\log\BufferedAppender;
+use util\log\Logging;
 use webservices\rest\Endpoint;
 
 class ExecuteTest extends TestCase {
@@ -56,6 +58,23 @@ class ExecuteTest extends TestCase {
     $this->assertEquals(
       "GET / HTTP/1.1\r\nConnection: close\r\nHost: test\r\nCookie: session=0x6100; lang=de\r\n\r\n",
       $resource->get()->content()
+    );
+  }
+
+  #[@test]
+  public function logging() {
+    $fixture= (new Endpoint('http://test'))->connecting(function($uri) { return new TestConnection($uri); });
+
+    $log= new BufferedAppender();
+    $fixture->setTrace(Logging::all()->to($log));
+
+    $fixture->resource('/users/0')->get();
+
+    $buf= $log->getBuffer();
+    $this->assertEquals(
+      ['req' => 1, 'res' => 1],
+      ['req' => preg_match('~GET /users/0 HTTP/1\.1~', $buf), 'res' => preg_match('~HTTP/1\.1 200 OK~', $buf)],
+      $buf
     );
   }
 }

--- a/src/test/php/webservices/rest/unittest/TestConnection.class.php
+++ b/src/test/php/webservices/rest/unittest/TestConnection.class.php
@@ -20,7 +20,7 @@ class TestConnection extends HttpConnection {
 
   public function finish(HttpOutputStream $stream) {
     return new HttpResponse(new MemoryInputStream(sprintf(
-      "HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s",
+      "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s",
       strlen($stream->bytes),
       $stream->bytes
     )));


### PR DESCRIPTION
This pull request implements the `util.log.Traceable` interface and traces requests and responses if a log category is given.

github.script.php:
```php
<?php namespace github;

use util\cmd\Console;
use util\log\Logging;
use webservices\rest\Endpoint;

$api= new Endpoint('https://api.github.com/');
$api->setTrace(Logging::all()->toConsole());

$res= $api->resource('/users/thekid/orgs')->with(['User-Agent' => $argv[0]])->get();

Console::writeLine($res->status(), ': ', $res->value());
```

![image](https://user-images.githubusercontent.com/696742/48023753-f5088b80-e13e-11e8-9015-aae8110a91ac.png)

*Note: This will be equivalent of using buffering for both request and response, and will use more memory. Especially for production, do not just log to /dev/null, instead, call `setTrace(null)` to ensure no logging is active!*