### PR TITLE
RestFormat

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@ Rest client change log
 
 ## ?.?.? / ????-??-??
 
+## 0.7.0 / 2018-11-05
+
+* Merge PR #7: Logging - @thekid
 * Improved `Endpoint::connecting()` to also accept callables using either
   the array or "Class::method" string syntax.
   (@thekid)

--- a/src/main/php/webservices/rest/Formats.class.php
+++ b/src/main/php/webservices/rest/Formats.class.php
@@ -7,7 +7,7 @@ use webservices\rest\format\Unsupported;
 /**
  * Formats registry
  *
- * @test  xp://web.rest.unittest.FormatsTest
+ * @test  xp://webservices.rest.unittest.FormatsTest
  */
 class Formats {
   private $matches= [], $patterns= [];
@@ -28,7 +28,7 @@ class Formats {
    * Adds a mime type
    *
    * @param  string $mime
-   * @param  web.rest.format.Format $format
+   * @param  webservices.rest.format.Format $format
    * @return self
    */
   public function with($mime, $format) {
@@ -40,7 +40,7 @@ class Formats {
    * Adds a mime type pattern 
    *
    * @param  string $pattern Pattern, using `*` as placeholder for one or more characters
-   * @param  web.rest.format.Format $format
+   * @param  webservices.rest.format.Format $format
    * @return self
    */
   public function matching($pattern, $format) {
@@ -51,8 +51,8 @@ class Formats {
   /**
    * Returns a type for a given header
    *
-   * @param  string $header
-   * @return web.rest.format.Format
+   * @param  string|webservices.rest.RestFormat $header
+   * @return webservices.rest.format.Format
    */
   public function named($header) {
     $mime= substr($header, 0, strcspn($header, ';'));    // FIXME: What to do with charset?

--- a/src/main/php/webservices/rest/RestFormat.class.php
+++ b/src/main/php/webservices/rest/RestFormat.class.php
@@ -1,0 +1,33 @@
+<?php namespace webservices\rest;
+
+use lang\Enum;
+
+class RestFormat extends Enum {
+  public static $JSON, $XML, $FORM;
+
+  private $mime;
+
+  static function __static() {
+    self::$JSON= new self(1, 'JSON', 'application/json');
+    self::$XML= new self(2, 'XML', 'text/xml');
+    self::$FORM= new self(3, 'FORM', 'application/x-www-form-urlencoded');
+  }
+
+  /**
+   * Creates a new REST Format
+   *
+   * @param  int $ordinal
+   * @param  string $name
+   * @param  string $mime
+   */
+  public function __construct($ordinal, $name, $mime) {
+    parent::__construct($ordinal, $name);
+    $this->mime= $mime;
+  }
+
+  /** @return string */
+  public function mime() { return $this->mime; }
+
+  /** @return string */
+  public function __toString() { return $this->mime; }
+}

--- a/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
@@ -63,7 +63,7 @@ class ExecuteTest extends TestCase {
 
   #[@test]
   public function logging() {
-    $fixture= (new Endpoint('http://test'))->connecting(function($uri) { return new TestConnection($uri); });
+    $fixture= (new Endpoint('http://test'))->connecting([TestConnection::class, 'new']);
 
     $log= new BufferedAppender();
     $fixture->setTrace(Logging::all()->to($log));

--- a/src/test/php/webservices/rest/unittest/FormatsTest.class.php
+++ b/src/test/php/webservices/rest/unittest/FormatsTest.class.php
@@ -2,6 +2,7 @@
 
 use unittest\TestCase;
 use webservices\rest\Formats;
+use webservices\rest\RestFormat;
 use webservices\rest\format\FormUrlencoded;
 use webservices\rest\format\Format;
 use webservices\rest\format\Json;
@@ -27,6 +28,11 @@ class FormatsTest extends TestCase {
   #[@test]
   public function supports_json_vendor_types_by_default() {
     $this->assertInstanceOf(Json::class, Formats::defaults()->named('application/vnd.github.v3+json'));
+  }
+
+  #[@test]
+  public function using_restformat_enum() {
+    $this->assertInstanceOf(Json::class, Formats::defaults()->named(RestFormat::$JSON));
   }
 
   #[@test]


### PR DESCRIPTION
This PR reduces BC breaks by adding `webservices.rest.RestFormat` class like in xp-framework/rest