### PR TITLE
Ensure all vendor classes are loaded

### DIFF
--- a/class.pth
+++ b/class.pth
@@ -1,2 +1,3 @@
 src/main/php/
+vendor/autoload.php
 src/test/php/


### PR DESCRIPTION
Running `$ git clone $URL; composer install; xp test src/test/php` yields the error that it can't load a dependency class from the vendor directory: `Uncaught exception: Exception lang.ClassFormatException (Class "peer.URL" could not be found in webservices.rest.unittest.EndpointTest, line 27)`. Adding `vendor/autoload.php` to the class.pth file solves this.