### PR TITLE
Implement support for ndjson

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "xp-framework/tokenize": "^8.0",
     "xp-forge/json": "^3.1",
     "xp-forge/uri": "^1.3",
-    "xp-forge/marshalling": "^0.3",
+    "xp-forge/marshalling": "^0.2 | ^0.3",
     "php": ">=5.6.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "xp-framework/tokenize": "^8.0",
     "xp-forge/json": "^3.1",
     "xp-forge/uri": "^1.3",
-    "xp-forge/marshalling": "^0.2",
+    "xp-forge/marshalling": "^0.3",
     "php": ">=5.6.0"
   },
   "require-dev" : {

--- a/src/main/php/webservices/rest/Formats.class.php
+++ b/src/main/php/webservices/rest/Formats.class.php
@@ -2,6 +2,7 @@
 
 use webservices\rest\format\FormUrlencoded;
 use webservices\rest\format\Json;
+use webservices\rest\format\NdJson;
 use webservices\rest\format\Unsupported;
 
 /**
@@ -19,6 +20,7 @@ class Formats {
    */
   public static function defaults() {
     $self= new self();
+    $self->matches[NdJson::MIMETYPE]= new NdJson();
     $self->patterns['#^application/vnd\.(.+)\+json$#']= $self->matches['application/json']= new Json();
     $self->matches['application/x-www-form-urlencoded']= new FormUrlencoded();
     return $self;
@@ -37,7 +39,7 @@ class Formats {
   }
 
   /**
-   * Adds a mime type pattern 
+   * Adds a mime type pattern
    *
    * @param  string $pattern Pattern, using `*` as placeholder for one or more characters
    * @param  webservices.rest.format.Format $format

--- a/src/main/php/webservices/rest/format/NdJson.class.php
+++ b/src/main/php/webservices/rest/format/NdJson.class.php
@@ -5,7 +5,6 @@ use io\streams\LinesIn;
 use text\json\Format as WireFormat;
 use text\json\StringInput;
 use text\json\StreamOutput;
-use util\XPIterator;
 /**
  * Implements ndjson.
  *
@@ -37,11 +36,6 @@ class NdJson extends Format {
       foreach ($value as $val) {
         $out->write($val); // ensure our value is written as JSON to the stream
         $stream->write("\n"); // write newline to stream directly so it's not encoded as JSON string
-      }
-    } else if ($value instanceof XPIterator) {
-      while ($value->hasNext()) {
-        $out->write($value->next());
-        $stream->write("\n");
       }
     } else {
       $out->write($value);

--- a/src/main/php/webservices/rest/format/NdJson.class.php
+++ b/src/main/php/webservices/rest/format/NdJson.class.php
@@ -1,0 +1,60 @@
+<?php namespace webservices\rest\format;
+
+use io\streams\LinesIn;
+use text\json\Format as WireFormat;
+use text\json\StringInput;
+use text\json\StreamOutput;
+/**
+ * Implements ndjson.
+ *
+ * @see http://ndjson.org
+ */
+class NdJson extends Format {
+  const MIMETYPE= 'application/x-ndjson';
+  private $format;
+
+  /**
+   * Constructor
+   *
+   * @param  text.json.Format $format Optional wire format, defaults to *dense*
+   */
+  public function __construct(WireFormat $format= null) {
+    $this->format= $format ?: WireFormat::dense();
+  }
+
+  /**
+   * Serialize a value and write it to the given stream
+   *
+   * @param  var $value
+   * @param  io.streams.OutputStream $stream
+   * @return io.streams.OutputStream
+   */
+  public function serialize($value, $stream) {
+    $out= new StreamOutput($stream, $this->format);
+    if (is_array($value) && is_int(key($value))) {
+      foreach ($value as $val) {
+        $out->write($val); // ensure our value is written as JSON to the stream
+        $stream->write("\n"); // write newline to stream directly so it's not encoded as JSON string
+      }
+    } else {
+      $out->write($value);
+    }
+
+    return $stream;
+  }
+
+  /**
+   * Deserialize a value from a given stream
+   *
+   * @param  io.streams.InputStream
+   * @return var
+   */
+  public function deserialize($stream) {
+    $vals= [];
+    foreach ((new LinesIn($stream)) as $line) {
+      $vals[]= (new StringInput($line))->read();
+    }
+
+    return $vals;
+  }
+}

--- a/src/test/php/webservices/rest/unittest/FormatsTest.class.php
+++ b/src/test/php/webservices/rest/unittest/FormatsTest.class.php
@@ -6,6 +6,7 @@ use webservices\rest\RestFormat;
 use webservices\rest\format\FormUrlencoded;
 use webservices\rest\format\Format;
 use webservices\rest\format\Json;
+use webservices\rest\format\NdJson;
 use webservices\rest\format\Unsupported;
 
 class FormatsTest extends TestCase {
@@ -18,6 +19,11 @@ class FormatsTest extends TestCase {
   #[@test]
   public function supports_json_by_default() {
     $this->assertInstanceOf(Json::class, Formats::defaults()->named('application/json'));
+  }
+
+  #[@test]
+  public function supports_ndjson_by_default() {
+    $this->assertInstanceOf(NdJson::class, Formats::defaults()->named(NdJson::MIMETYPE));
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/format/NdJsonTest.class.php
+++ b/src/test/php/webservices/rest/unittest/format/NdJsonTest.class.php
@@ -1,0 +1,49 @@
+<?php namespace webservices\rest\unittest\format;
+
+use io\streams\MemoryInputStream;
+use io\streams\MemoryOutputStream;
+use lang\XPException;
+use unittest\TestCase;
+use webservices\rest\format\NdJson;
+
+class NdJsonTest extends TestCase {
+
+  #[@test]
+  public function can_create() {
+    new NdJson();
+  }
+
+  #[@test, @values([
+  #  [['some', 'value'], '"some"
+  #"value"
+  #'],
+  #  [['key' => 'value'], '{"key":"value"}'],
+  #  [[['key' => 'value'], ['other'=>'value']], '{"key":"value"}
+  #{"other":"value"}
+  #'],
+  #])]
+  public function serialize($value, $expected) {
+    $this->assertEquals($expected, (new NdJson())->serialize($value, new MemoryOutputStream())->getBytes());
+  }
+
+  #[@test, @values([
+  #  [[], '{}'],
+  #  [['key' => 'value'], '{"key":"value"}'],
+  #])]
+  public function serialize_object($map, $expected) {
+    $this->assertEquals($expected, (new NdJson())->serialize((object)$map, new MemoryOutputStream())->getBytes());
+  }
+
+  #[@test, @values([
+  #  ['"some"
+  #"value"
+  #', ['some', 'value']],
+  #  ['{"key":"value"}', [['key' => 'value']]],
+  #  ['{"key":"value"}
+  #{"other":"value"}
+  #', [['key' => 'value'], ['other'=>'value']]],
+  #])]
+  public function deserialize($value, $expected) {
+    $this->assertEquals($expected, (new NdJson())->deserialize(new MemoryInputStream($value)));
+  }
+}

--- a/src/test/php/webservices/rest/unittest/format/NdJsonTest.class.php
+++ b/src/test/php/webservices/rest/unittest/format/NdJsonTest.class.php
@@ -4,7 +4,6 @@ use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
 use lang\XPException;
 use unittest\TestCase;
-use util\XPIterator;
 use webservices\rest\format\NdJson;
 
 class NdJsonTest extends TestCase {
@@ -21,16 +20,6 @@ class NdJsonTest extends TestCase {
   #])]
   public function serialize($value, $expected) {
     $this->assertEquals($expected, (new NdJson())->serialize(new \ArrayIterator($value), new MemoryOutputStream())->getBytes());
-  }
-
-  #[@test]
-  public function serialize_util_Iterators() {
-    $i= newinstance(XPIterator::class, [], [
-      'backing' => [1, 2, 3],
-      'next' => function() { return array_shift($this->backing); },
-      'hasNext' => function() { return !empty($this->backing); }
-    ]);
-    $this->assertEquals("1\n2\n3\n", (new NdJson())->serialize($i, new MemoryOutputStream())->getBytes());
   }
 
   #[@test, @values([


### PR DESCRIPTION
This adds support for [ndjson](http://ndjson.org).

As the `Format::serialize()` method always received the complete payload it is hard to differentiate between the elements that should become a single line containing valid JSON. Thus this implementation assumes that whenever it receives a Traversable that the payload consists of several elements that each should become its own line. If the payload should be a Traversable itself it can be wrapped inside an array before it is passed to serialization.

In return, as `Format::deserialize()`always receives the complete response, it will parse single lines and yield the single elements.