### PR TITLE
Fluent result interface

### DIFF
--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -90,11 +90,11 @@ class RestResponse implements Value {
   }
 
   /**
-   * Returns a result instance representing the data in this response.
+   * Returns a format instance representing the data format in this response.
    *
-   * @return webservices.rest.Result
+   * @return webservices.rest.format.Format
    */
-  public function result() { return new Result($this); }
+  public function format() { return $this->reader->format(); }
 
   /**
    * Returns the response as a stream
@@ -120,6 +120,13 @@ class RestResponse implements Value {
       $s->close();
     }
   }
+
+  /**
+   * Returns a result instance representing the data in this response.
+   *
+   * @return webservices.rest.Result
+   */
+  public function result() { return new Result($this); }
 
   /** @return string */
   public function hashCode() { return spl_object_hash($this); }

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -90,18 +90,11 @@ class RestResponse implements Value {
   }
 
   /**
-   * Returns a value from the response, using the given type for deserialization.
-   * Like value() but throws an exception if the HTTP statuscode is 400 and above.
+   * Returns a result instance representing the data in this response.
    *
-   * @param  string $type
-   * @return var
-   * @throws webservices.rest.UnexpectedError
+   * @return webservices.rest.Result
    */
-  public function result($type= 'var') {
-    if ($this->status < 400) return $this->reader->read($type);
-
-    throw new UnexpectedError($this->status, $this->message, $this->reader->stream());
-  }
+  public function result() { return new Result($this); }
 
   /**
    * Returns the response as a stream

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -90,6 +90,20 @@ class RestResponse implements Value {
   }
 
   /**
+   * Returns a value from the response, using the given type for deserialization.
+   * Like value() but throws an exception if the HTTP statuscode is 400 and above.
+   *
+   * @param  string $type
+   * @return var
+   * @throws webservices.rest.UnexpectedError
+   */
+  public function result($type= 'var') {
+    if ($this->status < 400) return $this->reader->read($type);
+
+    throw new UnexpectedError($this->status, $this->message, $this->reader->stream());
+  }
+
+  /**
    * Returns the response as a stream
    *
    * @return io.stream.InputStream

--- a/src/main/php/webservices/rest/Result.class.php
+++ b/src/main/php/webservices/rest/Result.class.php
@@ -1,5 +1,7 @@
 <?php namespace webservices\rest;
 
+use webservices\rest\format\Unsupported;
+
 class Result {
   private $response;
 
@@ -18,5 +20,22 @@ class Result {
     if ($this->response->status() < 400) return $this->response->value($type);
 
     throw new UnexpectedError($this->response);
+  }
+
+  /**
+   * Returns the error from the response, using the given type for deserialization.
+   * Falls back to using the complete body as a string if the response format is
+   * unsupported.
+   *
+   * @param  string $type
+   * @return var
+   */
+  public function error($type= 'var') {
+    if ($this->response->status() < 400) return null;
+
+    return $this->response->format() instanceof Unsupported
+      ? $this->response->content()
+      : $this->response->value($type)
+    ;
   }
 }

--- a/src/main/php/webservices/rest/Result.class.php
+++ b/src/main/php/webservices/rest/Result.class.php
@@ -2,6 +2,13 @@
 
 use webservices\rest\format\Unsupported;
 
+/**
+ * Result is a high-level abstraction of a REST API's results.
+ *
+ * @see   https://github.com/xp-forge/rest-client/pull/14
+ * @see   webservices.rest.RestResponse::result()
+ * @test  webservices.rest.unittest.ResultTest
+ */
 class Result {
   private $response;
 

--- a/src/main/php/webservices/rest/Result.class.php
+++ b/src/main/php/webservices/rest/Result.class.php
@@ -8,8 +8,34 @@ class Result {
   /** @param webservices.rest.RestResponse */
   public function __construct($response) { $this->response= $response; }
 
+  /**
+   * Returns the resolved `Location` header from the response. Throws an
+   * exception if the header is not present.
+   *
+   * @return util.URI
+   * @throws webservices.rest.UnexpectedStatus
+   */
   public function location() {
     if ($l= $this->response->location()) return $l;
+
+    throw new UnexpectedStatus($this->response);
+  }
+
+  /**
+   * Matches response status codes and returns values based on the given cases.
+   * A case is an integer status code mapped to either a given value or a
+   * function which receives a `RestResponse` and returns a value.
+   *
+   * @param  [:var] $cases
+   * @return var
+   * @throws webservices.rest.UnexpectedStatus
+   */
+  public function match(array $cases) {
+    $s= $this->response->status();
+    if (array_key_exists($s, $cases)) return $cases[$s] instanceof \Closure
+      ? $cases[$s]($this->response)
+      : $cases[$s]
+    ;
 
     throw new UnexpectedStatus($this->response);
   }

--- a/src/main/php/webservices/rest/Result.class.php
+++ b/src/main/php/webservices/rest/Result.class.php
@@ -12,12 +12,29 @@ class Result {
    * Returns a value from the response, using the given type for deserialization.
    * Throws an exception if the HTTP statuscode is 400 and above.
    *
-   * @param  string $type
+   * @param  ?string $type
    * @return var
    * @throws webservices.rest.UnexpectedError
    */
-  public function value($type= 'var') {
-    if ($this->response->status() < 400) return $this->response->value($type);
+  public function value($type= null) {
+    if ($this->response->status() < 400) return $this->response->value($type ?? 'var');
+
+    throw new UnexpectedError($this->response);
+  }
+
+  /**
+   * Returns a value from the response, using the given type for deserialization.
+   * Returns NULL for a given list of status codes indicating absence, defaulting
+   * to 404s. Throws an exception if the HTTP statuscode is 400 and above.
+   *
+   * @param  ?string $type
+   * @param  int[] $absent Status code indicating absence
+   * @return var
+   * @throws webservices.rest.UnexpectedError
+   */
+  public function optional($type= null, $absent= [404]) {
+    if ($this->response->status() < 400) return $this->response->value($type ?? 'var');
+    if (in_array($this->response->status(), $absent)) return null;
 
     throw new UnexpectedError($this->response);
   }
@@ -27,15 +44,15 @@ class Result {
    * Falls back to using the complete body as a string if the response format is
    * unsupported.
    *
-   * @param  string $type
+   * @param  ?string $type
    * @return var
    */
-  public function error($type= 'var') {
+  public function error($type= null) {
     if ($this->response->status() < 400) return null;
 
     return $this->response->format() instanceof Unsupported
       ? $this->response->content()
-      : $this->response->value($type)
+      : $this->response->value($type ?? 'var')
     ;
   }
 }

--- a/src/main/php/webservices/rest/Result.class.php
+++ b/src/main/php/webservices/rest/Result.class.php
@@ -8,6 +8,12 @@ class Result {
   /** @param webservices.rest.RestResponse */
   public function __construct($response) { $this->response= $response; }
 
+  public function location() {
+    if ($l= $this->response->location()) return $l;
+
+    throw new UnexpectedStatus($this->response);
+  }
+
   /**
    * Returns a value from the response, using the given type for deserialization.
    * Throws an exception if the HTTP statuscode is 400 and above.

--- a/src/main/php/webservices/rest/Result.class.php
+++ b/src/main/php/webservices/rest/Result.class.php
@@ -1,0 +1,22 @@
+<?php namespace webservices\rest;
+
+class Result {
+  private $response;
+
+  /** @param webservices.rest.RestResponse */
+  public function __construct($response) { $this->response= $response; }
+
+  /**
+   * Returns a value from the response, using the given type for deserialization.
+   * Throws an exception if the HTTP statuscode is 400 and above.
+   *
+   * @param  string $type
+   * @return var
+   * @throws webservices.rest.UnexpectedError
+   */
+  public function value($type= 'var') {
+    if ($this->response->status() < 400) return $this->response->value($type);
+
+    throw new UnexpectedError($this->response);
+  }
+}

--- a/src/main/php/webservices/rest/Result.class.php
+++ b/src/main/php/webservices/rest/Result.class.php
@@ -14,12 +14,13 @@ class Result {
    *
    * @param  ?string $type
    * @return var
-   * @throws webservices.rest.UnexpectedError
+   * @throws webservices.rest.UnexpectedStatus
    */
   public function value($type= null) {
-    if ($this->response->status() < 400) return $this->response->value($type ?? 'var');
+    $s= $this->response->status();
+    if ($s >= 200 && $s < 300) return $this->response->value($type ?? 'var');
 
-    throw new UnexpectedError($this->response);
+    throw new UnexpectedStatus($this->response);
   }
 
   /**
@@ -30,13 +31,14 @@ class Result {
    * @param  ?string $type
    * @param  int[] $absent Status code indicating absence
    * @return var
-   * @throws webservices.rest.UnexpectedError
+   * @throws webservices.rest.UnexpectedStatus
    */
   public function optional($type= null, $absent= [404]) {
-    if ($this->response->status() < 400) return $this->response->value($type ?? 'var');
-    if (in_array($this->response->status(), $absent)) return null;
+    $s= $this->response->status();
+    if ($s >= 200 && $s < 300) return $this->response->value($type ?? 'var');
+    if (in_array($s, $absent)) return null;
 
-    throw new UnexpectedError($this->response);
+    throw new UnexpectedStatus($this->response);
   }
 
   /**

--- a/src/main/php/webservices/rest/UnexpectedError.class.php
+++ b/src/main/php/webservices/rest/UnexpectedError.class.php
@@ -3,25 +3,18 @@
 use lang\IllegalStateException;
 
 class UnexpectedError extends IllegalStateException {
-  private $status, $stream;
+  private $response;
 
-  /**
-   * Creates a new instance
-   *
-   * @param  int $status
-   * @param  string $message
-   * @param  io.stream.InputStream $stream
-   */
-  public function __construct($status, $message, $stream) {
-    parent::__construct('Unexpected '.$status.' ('.$message.')');
-    $this->status= $status;
-    $this->stream= $stream;
+  /** @param webservices.rest.RestResponse */
+  public function __construct($response) {
+    parent::__construct('Unexpected '.$response->status().' ('.$response->message().')');
+    $this->response= $response;
   }
 
   /** @return int */
-  public function status() { return $this->status; }
+  public function status() { return $this->response->status(); }
 
-  /** @return io.stream.InputStream */
-  public function stream() { return $this->stream; }
+  /** @return webservices.rest.RestResponse */
+  public function response() { return $this->response; }
 
 }

--- a/src/main/php/webservices/rest/UnexpectedError.class.php
+++ b/src/main/php/webservices/rest/UnexpectedError.class.php
@@ -1,6 +1,7 @@
 <?php namespace webservices\rest;
 
 use lang\IllegalStateException;
+use webservices\rest\format\Unsupported;
 
 class UnexpectedError extends IllegalStateException {
   private $response;
@@ -14,7 +15,17 @@ class UnexpectedError extends IllegalStateException {
   /** @return int */
   public function status() { return $this->response->status(); }
 
-  /** @return webservices.rest.RestResponse */
-  public function response() { return $this->response; }
-
+  /**
+   * Returns error from this response, deserializing content if possible.
+   *
+   * @see    webservices.rest.Result::error()
+   * @param  ?string $type
+   * @return var
+   */
+  public function error($type= null) {
+    return $this->response->format() instanceof Unsupported
+      ? $this->response->content()
+      : $this->response->value($type ?? 'var')
+    ;
+  }
 }

--- a/src/main/php/webservices/rest/UnexpectedError.class.php
+++ b/src/main/php/webservices/rest/UnexpectedError.class.php
@@ -1,0 +1,27 @@
+<?php namespace webservices\rest;
+
+use lang\IllegalStateException;
+
+class UnexpectedError extends IllegalStateException {
+  private $status, $stream;
+
+  /**
+   * Creates a new instance
+   *
+   * @param  int $status
+   * @param  string $message
+   * @param  io.stream.InputStream $stream
+   */
+  public function __construct($status, $message, $stream) {
+    parent::__construct('Unexpected '.$status.' ('.$message.')');
+    $this->status= $status;
+    $this->stream= $stream;
+  }
+
+  /** @return int */
+  public function status() { return $this->status; }
+
+  /** @return io.stream.InputStream */
+  public function stream() { return $this->stream; }
+
+}

--- a/src/main/php/webservices/rest/UnexpectedStatus.class.php
+++ b/src/main/php/webservices/rest/UnexpectedStatus.class.php
@@ -16,13 +16,13 @@ class UnexpectedStatus extends IllegalStateException {
   public function status() { return $this->response->status(); }
 
   /**
-   * Returns error from this response, deserializing content if possible.
+   * Returns body from this response, deserializing if possible.
    *
    * @see    webservices.rest.Result::error()
    * @param  ?string $type
    * @return var
    */
-  public function error($type= null) {
+  public function cause($type= null) {
     return $this->response->format() instanceof Unsupported
       ? $this->response->content()
       : $this->response->value($type ?? 'var')

--- a/src/main/php/webservices/rest/UnexpectedStatus.class.php
+++ b/src/main/php/webservices/rest/UnexpectedStatus.class.php
@@ -22,7 +22,7 @@ class UnexpectedStatus extends IllegalStateException {
    * @param  ?string $type
    * @return var
    */
-  public function cause($type= null) {
+  public function reason($type= null) {
     return $this->response->format() instanceof Unsupported
       ? $this->response->content()
       : $this->response->value($type ?? 'var')

--- a/src/main/php/webservices/rest/UnexpectedStatus.class.php
+++ b/src/main/php/webservices/rest/UnexpectedStatus.class.php
@@ -3,7 +3,7 @@
 use lang\IllegalStateException;
 use webservices\rest\format\Unsupported;
 
-class UnexpectedError extends IllegalStateException {
+class UnexpectedStatus extends IllegalStateException {
   private $response;
 
   /** @param webservices.rest.RestResponse */

--- a/src/main/php/webservices/rest/io/Reader.class.php
+++ b/src/main/php/webservices/rest/io/Reader.class.php
@@ -13,6 +13,9 @@ class Reader {
     $this->marshalling= $marshalling;
   }
 
+  /** @return webservices.rest.format.Format */
+  public function format() { return $this->format; }
+
   /** @return io.streams.InputStream */
   public function stream() { return $this->stream; }
 

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -5,9 +5,9 @@ use lang\IllegalStateException;
 use unittest\{Test, TestCase, Values};
 use util\URI;
 use util\data\Marshalling;
-use webservices\rest\format\{Json, Unsupported};
+use webservices\rest\format\Json;
 use webservices\rest\io\Reader;
-use webservices\rest\{Cookie, Cookies, Link, RestResponse, UnexpectedError};
+use webservices\rest\{Cookie, Cookies, Link, RestResponse};
 
 class RestResponseTest extends TestCase {
 
@@ -119,24 +119,10 @@ class RestResponseTest extends TestCase {
   }
 
   #[Test]
-  public function result_on_success() {
+  public function result() {
     $stream= new MemoryInputStream('{"key":"value"}');
     $reader= new Reader($stream, new Json(), new Marshalling());
-    $this->assertEquals(['key' => 'value'], (new RestResponse(200, 'OK', [], $reader))->result());
-  }
-
-  #[Test, Expect(class: UnexpectedError::class, withMessage: 'Unexpected 404 (Not found)')]
-  public function result_on_error() {
-    $stream= new MemoryInputStream('{"error":"No such test #404"}');
-    $reader= new Reader($stream, new Json(), new Marshalling());
-    (new RestResponse(404, 'Not found', [], $reader))->result();
-  }
-
-  #[Test, Expect(class: UnexpectedError::class, withMessage: 'Unexpected 504 (Gateway Timeout)')]
-  public function result_on_raw_error() {
-    $stream= new MemoryInputStream('Could not reach backend');
-    $reader= new Reader($stream, new Unsupported('text/plain'), new Marshalling());
-    (new RestResponse(504, 'Gateway Timeout', [], $reader))->result();
+    $this->assertEquals(['key' => 'value'], (new RestResponse(200, 'OK', [], $reader))->result()->value());
   }
 
   #[Test]

--- a/src/test/php/webservices/rest/unittest/ResultTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ResultTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace webservices\rest\unittest;
 
 use io\streams\MemoryInputStream;
-use unittest\{Assert, Test, Values};
+use unittest\{Assert, AssertionFailedError, Test, Values};
 use util\data\Marshalling;
 use webservices\rest\format\{Json, Unsupported};
 use webservices\rest\io\Reader;
@@ -40,6 +40,18 @@ class ResultTest {
   public function value_on_error() {
     $response= new RestResponse(404, 'Not Found', ...$this->json('{"error":"No such test #0"}'));
     (new Result($response))->value();
+  }
+
+  #[Test]
+  public function access_error() {
+    $response= new RestResponse(404, 'Not Found', ...$this->json('{"error":"No such test #0"}'));
+    try {
+      (new Result($response))->value();
+      throw new AssertionFailedError('No exception raised');
+    } catch (UnexpectedError $e) {
+      Assert::equals(404, $e->status());
+      Assert::equals(['error' => 'No such test #0'], $e->error());
+    }
   }
 
   #[Test]

--- a/src/test/php/webservices/rest/unittest/ResultTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ResultTest.class.php
@@ -59,4 +59,28 @@ class ResultTest {
     $response= new RestResponse(504, 'Gateway Timeout', ...$this->text('Could not reach database'));
     Assert::equals('Could not reach database', (new Result($response))->error());
   }
+
+  #[Test]
+  public function optional_on_success() {
+    $response= new RestResponse(200, 'OK', ...$this->json('{"key":"value"}'));
+    Assert::equals(['key' => 'value'], (new Result($response))->optional());
+  }
+
+  #[Test]
+  public function optional_on_404() {
+    $response= new RestResponse(404, 'Not Found', ...$this->json('{"error":"No such test #0"}'));
+    Assert::null((new Result($response))->optional());
+  }
+
+  #[Test]
+  public function optional_on_supplied_status_code() {
+    $response= new RestResponse(406, 'Not Acceptable', ...$this->json('{"error":"This is an XML-free API"}'));
+    Assert::null((new Result($response))->optional(null, [404, 406]));
+  }
+
+  #[Test, Expect(class: UnexpectedError::class, withMessage: 'Unexpected 504 (Gateway Timeout)')]
+  public function optional_on_error() {
+    $response= new RestResponse(504, 'Gateway Timeout', ...$this->text('Could not reach database'));
+    (new Result($response))->value();
+  }
 }

--- a/src/test/php/webservices/rest/unittest/ResultTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ResultTest.class.php
@@ -160,14 +160,14 @@ class ResultTest {
   }
 
   #[Test]
-  public function access_body_of_unexpected_status() {
+  public function access_reason_of_unexpected_status() {
     $response= new RestResponse(404, 'Not Found', ...$this->json('{"error":"No such test #0"}'));
     try {
       (new Result($response))->value();
       throw new AssertionFailedError('No exception raised');
     } catch (UnexpectedStatus $e) {
       Assert::equals(404, $e->status());
-      Assert::equals(['error' => 'No such test #0'], $e->cause());
+      Assert::equals(['error' => 'No such test #0'], $e->reason());
     }
   }
 }

--- a/src/test/php/webservices/rest/unittest/ResultTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ResultTest.class.php
@@ -49,14 +49,14 @@ class ResultTest {
   }
 
   #[Test]
-  public function access_error() {
+  public function access_body_of_unexpected_status() {
     $response= new RestResponse(404, 'Not Found', ...$this->json('{"error":"No such test #0"}'));
     try {
       (new Result($response))->value();
       throw new AssertionFailedError('No exception raised');
     } catch (UnexpectedStatus $e) {
       Assert::equals(404, $e->status());
-      Assert::equals(['error' => 'No such test #0'], $e->error());
+      Assert::equals(['error' => 'No such test #0'], $e->cause());
     }
   }
 

--- a/src/test/php/webservices/rest/unittest/ResultTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ResultTest.class.php
@@ -96,6 +96,12 @@ class ResultTest {
     Assert::null((new Result($response))->optional(null, [404, 406]));
   }
 
+  #[Test, Expect(class: UnexpectedStatus::class, withMessage: 'Unexpected 302 (Found)')]
+  public function optional_on_redirect() {
+    $response= new RestResponse(302, 'Found', ['Location' => 'http://example.org/']);
+    (new Result($response))->optional();
+  }
+
   #[Test, Expect(class: UnexpectedStatus::class, withMessage: 'Unexpected 504 (Gateway Timeout)')]
   public function optional_on_error() {
     $response= new RestResponse(504, 'Gateway Timeout', ...$this->text('Could not reach database'));

--- a/src/test/php/webservices/rest/unittest/ResultTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ResultTest.class.php
@@ -8,19 +8,22 @@ use webservices\rest\io\Reader;
 use webservices\rest\{Result, RestResponse, UnexpectedError};
 
 class ResultTest {
-  const TEXT= ['Content-Type' => 'text/plain'];
-  const JSON= ['Content-Type' => 'application/json'];
 
   /** Returns a textual response */
   private function text($body) {
-    return new Reader(new MemoryInputStream($body), new Unsupported('text/plain'), new Marshalling());
+    return [
+      ['Content-Type' => 'text/plain'],
+      new Reader(new MemoryInputStream($body), new Unsupported('text/plain'), new Marshalling())
+    ];
   }
 
   /** Returns a JSON response */
   private function json($body) {
-    return new Reader(new MemoryInputStream($body), new Json(), new Marshalling());
+    return [
+      ['Content-Type' => 'application/json'],
+      new Reader(new MemoryInputStream($body), new Json(), new Marshalling())
+    ];
   }
-
 
   #[Test]
   public function can_create() {
@@ -29,31 +32,31 @@ class ResultTest {
 
   #[Test]
   public function value_on_success() {
-    $response= new RestResponse(200, 'OK', self::JSON, $this->json('{"key":"value"}'));
+    $response= new RestResponse(200, 'OK', ...$this->json('{"key":"value"}'));
     Assert::equals(['key' => 'value'], (new Result($response))->value());
   }
 
   #[Test, Expect(class: UnexpectedError::class, withMessage: 'Unexpected 404 (Not Found)')]
   public function value_on_error() {
-    $response= new RestResponse(404, 'Not Found', self::JSON, $this->json('{"error":"No such test #0"}'));
+    $response= new RestResponse(404, 'Not Found', ...$this->json('{"error":"No such test #0"}'));
     (new Result($response))->value();
   }
 
   #[Test]
   public function error_is_null_for_successful_requests() {
-    $response= new RestResponse(200, 'OK', self::JSON, $this->json('{"key":"value"}'));
+    $response= new RestResponse(200, 'OK', ...$this->json('{"key":"value"}'));
     Assert::null((new Result($response))->error());
   }
 
   #[Test]
   public function error_unserialized_from_response() {
-    $response= new RestResponse(404, 'Not Found', self::JSON, $this->json('{"error":"No such test #0"}'));
+    $response= new RestResponse(404, 'Not Found', ...$this->json('{"error":"No such test #0"}'));
     Assert::equals(['error' => 'No such test #0'], (new Result($response))->error());
   }
 
   #[Test]
   public function error_for_raw_response() {
-    $response= new RestResponse(504, 'Gateway Timeout', self::TEXT, $this->text('Could not reach database'));
+    $response= new RestResponse(504, 'Gateway Timeout', ...$this->text('Could not reach database'));
     Assert::equals('Could not reach database', (new Result($response))->error());
   }
 }

--- a/src/test/php/webservices/rest/unittest/ResultTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ResultTest.class.php
@@ -3,16 +3,24 @@
 use io\streams\MemoryInputStream;
 use unittest\{Assert, Test};
 use util\data\Marshalling;
-use webservices\rest\format\Json;
+use webservices\rest\format\{Json, Unsupported};
 use webservices\rest\io\Reader;
 use webservices\rest\{Result, RestResponse, UnexpectedError};
 
 class ResultTest {
-  const JSON = ['Content-Type' => 'application/json'];
+  const TEXT= ['Content-Type' => 'text/plain'];
+  const JSON= ['Content-Type' => 'application/json'];
 
-  private function reader($body) {
+  /** Returns a textual response */
+  private function text($body) {
+    return new Reader(new MemoryInputStream($body), new Unsupported('text/plain'), new Marshalling());
+  }
+
+  /** Returns a JSON response */
+  private function json($body) {
     return new Reader(new MemoryInputStream($body), new Json(), new Marshalling());
   }
+
 
   #[Test]
   public function can_create() {
@@ -20,14 +28,32 @@ class ResultTest {
   }
 
   #[Test]
-  public function value_on_succes() {
-    $response= new RestResponse(200, 'OK', self::JSON, $this->reader('{"key":"value"}'));
+  public function value_on_success() {
+    $response= new RestResponse(200, 'OK', self::JSON, $this->json('{"key":"value"}'));
     Assert::equals(['key' => 'value'], (new Result($response))->value());
   }
 
   #[Test, Expect(class: UnexpectedError::class, withMessage: 'Unexpected 404 (Not Found)')]
   public function value_on_error() {
-    $response= new RestResponse(404, 'Not Found', self::JSON, $this->reader('{"error":"No such test #0"}'));
+    $response= new RestResponse(404, 'Not Found', self::JSON, $this->json('{"error":"No such test #0"}'));
     (new Result($response))->value();
+  }
+
+  #[Test]
+  public function error_is_null_for_successful_requests() {
+    $response= new RestResponse(200, 'OK', self::JSON, $this->json('{"key":"value"}'));
+    Assert::null((new Result($response))->error());
+  }
+
+  #[Test]
+  public function error_unserialized_from_response() {
+    $response= new RestResponse(404, 'Not Found', self::JSON, $this->json('{"error":"No such test #0"}'));
+    Assert::equals(['error' => 'No such test #0'], (new Result($response))->error());
+  }
+
+  #[Test]
+  public function error_for_raw_response() {
+    $response= new RestResponse(504, 'Gateway Timeout', self::TEXT, $this->text('Could not reach database'));
+    Assert::equals('Could not reach database', (new Result($response))->error());
   }
 }

--- a/src/test/php/webservices/rest/unittest/ResultTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ResultTest.class.php
@@ -1,0 +1,33 @@
+<?php namespace webservices\rest\unittest;
+
+use io\streams\MemoryInputStream;
+use unittest\{Assert, Test};
+use util\data\Marshalling;
+use webservices\rest\format\Json;
+use webservices\rest\io\Reader;
+use webservices\rest\{Result, RestResponse, UnexpectedError};
+
+class ResultTest {
+  const JSON = ['Content-Type' => 'application/json'];
+
+  private function reader($body) {
+    return new Reader(new MemoryInputStream($body), new Json(), new Marshalling());
+  }
+
+  #[Test]
+  public function can_create() {
+    new Result(new RestResponse(200, 'OK'));
+  }
+
+  #[Test]
+  public function value_on_succes() {
+    $response= new RestResponse(200, 'OK', self::JSON, $this->reader('{"key":"value"}'));
+    Assert::equals(['key' => 'value'], (new Result($response))->value());
+  }
+
+  #[Test, Expect(class: UnexpectedError::class, withMessage: 'Unexpected 404 (Not Found)')]
+  public function value_on_error() {
+    $response= new RestResponse(404, 'Not Found', self::JSON, $this->reader('{"error":"No such test #0"}'));
+    (new Result($response))->value();
+  }
+}


### PR DESCRIPTION
This pull request adds two new accessors to responses which make writing concise handling code easier.

## Typical REST API paradigms

On top of 401 for authentication, 400 for format, 403 for permission and 5XX for internal errors, an API typically yields the following results that need to be dealt with:

* * * 

### Create
Returns either a 201 with a location header, or 200 with the created resource (see [this discussion](https://stackoverflow.com/questions/1860645/create-request-with-post-which-response-codes-200-or-201-and-content)), 422 for validation errors.

### Read (and list)
Returns 200 if found, 404 if not found, may include 303 for redirects or 304 for conditional requests (see [the GitHub API](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests) for an example why & how to use them).

### Update
Returns 200, or 202 if processing the update is performed asynchronously, 404 if the resource cannot be found, 409 for conflicts or 422 for validation errors.

### Delete
Returns 204, or 202 if processing the deletion is performed asynchronously, 404 if the resource cannot be found.

* * * 

For these cases, this pull request contains methods for fluent one-line handling.

## API

The RestResponse::result() method returns instances of the following class:

```php
public class webservices.rest.Result {
  public function __construct(webservices.rest.RestResponse $response)

  public function location(): util.URI
  public function match(array $cases): var
  public function value(?string $type): var
  public function optional(?string $type, int[] $absent): var
  public function error(?string $type): var
}
```

The following methods raise `webservices.rest.UnexpectedStatus` if assumptions they make fail:

* location() expects a `Location` header to be present
* match() will match the status code against the given cases map
* value() will check if the status code is in the range 200 - 299
* optional() will check if the status code is in the range 200 - 299 (returning a value), or 404 (returning NULL)

The error() method will return a value if the status code is greater than or equal to 400, NULL otherwise.

## Example (MeiliSearch)

The following implementation:

```php
class MeiliSearch {
  // ...shortened for brevity...

  /** Fetches a document, returning NULL if it cannot be found */
  public function document(string $index, string|int $id): ?array<string, mixed> {
    $r= $this->endpoint->resource('/indexes/{0}/documents/{1}', [$index, $id])->get();
    return match ($r->status()) {
      200 => $r->value(),
      404 => null,
      default => throw new IllegalStateException('Unexpected status '.$r->status()),
    };
  }

  /** Runs a search query and returns the results */
  public function query(string $index, ?string $term= null, array $parameters= []) {
    $r= $this->endpoint->resource('/indexes/{0}/search', [$index])->post(
      ['q' => (string)$term] + $parameters,
      'application/json'
    );
    return match ($r->status()) {
      200 => $r->value(),
      default => throw new IllegalStateException($r->content()),
    };
  }
}
```

...can be rewritten to the following:

```php
class MeiliSearch {
  // ...shortened for brevity...

  /** Fetches a document, returning NULL if it cannot be found */
  public function document(string $index, string|int $id): ?array<string, mixed> {
    return $this->endpoint->resource('/indexes/{0}/documents/{1}', [$index, $id])
      ->get()
      ->result()
      ->optional()
    ;
  }

  /** Runs a search query and returns the results */
  public function query(string $index, ?string $term= null, array $parameters= []) {
    return $this->endpoint->resource('/indexes/{0}/search', [$index])
      ->post(['q' => (string)$term] + $parameters, 'application/json')
      ->result()
      ->value()
    ;
  }
}
```

## Example (robust create handling)

The following can handle both 200 OK with the created resource and 201 Created with a location header:

```php
$id= $endpoint->resource('/users')->post($user, 'application/json')->result()->match([
  200 => function($r) { return $r->value()['id']; },
  201 => function($r) { return (int)basename($r->location()); }
]);
```

## Example (robust error handling)

This example takes care of fetching a user, which might not exist, including showing the error for unexpected statuses. It handles serialized errors as well as "raw" errors (*like proxy errors delivered as text/plain*).

```php
try {
  $user= $endpoint->resource('/users/{0}', [$id])->get()->result()->optional();
} catch (UnexpectedStatus $e) {
  Console::$err->writeLine('Could not fetch user #', $id, ': ', $e->reason());
  return 1;
}
```

## See also 

* https://docs.microsoft.com/en-us/azure/architecture/best-practices/api-design
* https://spec.openapis.org/oas/v3.1.0
* https://standards.rest/ and https://apisyouwonthate.com/