### PR TITLE
Deprecate high-level functions on low-level response

### DIFF
--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -20,7 +20,7 @@ class RestResponse implements Value {
    * @param  int $status
    * @param  string $message
    * @param  [:string|string[]] $headers
-   * @param  web.rest.Reader $reader
+   * @param  webservices.rest.io.Reader $reader
    * @param  string|?util.URI $uri The request URI, if available
    */
   public function __construct($status, $message, $headers= [], Reader $reader= null, $uri= null) {
@@ -48,11 +48,14 @@ class RestResponse implements Value {
   /** @return ?util.URI */
   public function uri() { return $this->uri; }
 
-  /** @return webservices.rest.format.Format */
-  public function format() { return $this->reader->format(); }
+  /** @return webservices.rest.io.Reader */
+  public function reader() { return $this->reader; }
 
   /** @return io.stream.InputStream */
   public function stream() { return $this->reader->stream(); }
+
+  /** @return string */
+  public function content() { return $this->reader->content(); }
 
   /**
    * Returns cookies sent by server.
@@ -121,24 +124,6 @@ class RestResponse implements Value {
    * @return webservices.rest.Result
    */
   public function result() { return new Result($this); }
-
-  /**
-   * Returns the response as a string
-   *
-   * @return string
-   */
-  public function content() {
-    $s= $this->reader->stream();
-    try {
-      $r= '';
-      while ($s->available()) {
-        $r.= $s->read();
-      }
-      return $r;
-    } finally {
-      $s->close();
-    }
-  }
 
   /** @return string */
   public function hashCode() { return spl_object_hash($this); }

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -45,27 +45,14 @@ class RestResponse implements Value {
   /** @return string */
   public function message() { return $this->message; }
 
-  /**
-   * Returns the value of the "Location" header, or NULL if it not present.
-   * The URI is resolved against the request URI.
-   *
-   * @return ?util.URI
-   */
-  public function location() {
-    if ($location= $this->header('Location')) {
-      return $this->uri ? $this->uri->resolve($location) : new URI($location);
-    }
-    return null;
-  }
+  /** @return ?util.URI */
+  public function uri() { return $this->uri; }
 
-  /**
-   * Returns links sent by server.
-   *
-   * @return webservices.rest.Links
-   */
-  public function links() {
-    return Links::in($this->header('Link'));
-  }
+  /** @return webservices.rest.format.Format */
+  public function format() { return $this->reader->format(); }
+
+  /** @return io.stream.InputStream */
+  public function stream() { return $this->reader->stream(); }
 
   /**
    * Returns cookies sent by server.
@@ -80,8 +67,47 @@ class RestResponse implements Value {
   }
 
   /**
+   * Resolves a URI
+   *
+   * @param  ?string|util.URI $uri
+   * @return ?util.URI
+   */
+  public function resolve($uri) {
+    if ($this->uri) {
+      return null === $uri ? $this->uri : $this->uri->resolve($uri);
+    } else {
+      return null === $uri ? null : new URI((string)$uri);
+    }
+  }
+
+  /**
+   * Returns the value of the "Location" header, or NULL if it not present.
+   * The URI is resolved against the request URI.
+   *
+   * @deprecated Use `self::result()->location()` or `self::header('Location')`
+   * @return ?util.URI
+   */
+  public function location() {
+    if ($location= $this->header('Location')) {
+      return $this->uri ? $this->uri->resolve($location) : new URI($location);
+    }
+    return null;
+  }
+
+  /**
+   * Returns links sent by server.
+   *
+   * @deprecated Use `self::result()->links()` or `self::header('Link')`
+   * @return webservices.rest.Links
+   */
+  public function links() {
+    return Links::in($this->header('Link'));
+  }
+
+  /**
    * Returns a value from the response, using the given type for deserialization
    *
+   * @deprecated Use `self::result()->value()`
    * @param  string $type
    * @return var
    */
@@ -90,18 +116,11 @@ class RestResponse implements Value {
   }
 
   /**
-   * Returns a format instance representing the data format in this response.
+   * Returns a result instance representing the data in this response.
    *
-   * @return webservices.rest.format.Format
+   * @return webservices.rest.Result
    */
-  public function format() { return $this->reader->format(); }
-
-  /**
-   * Returns the response as a stream
-   *
-   * @return io.stream.InputStream
-   */
-  public function stream() { return $this->reader->stream(); }
+  public function result() { return new Result($this); }
 
   /**
    * Returns the response as a string
@@ -120,13 +139,6 @@ class RestResponse implements Value {
       $s->close();
     }
   }
-
-  /**
-   * Returns a result instance representing the data in this response.
-   *
-   * @return webservices.rest.Result
-   */
-  public function result() { return new Result($this); }
 
   /** @return string */
   public function hashCode() { return spl_object_hash($this); }

--- a/src/main/php/webservices/rest/UnexpectedStatus.class.php
+++ b/src/main/php/webservices/rest/UnexpectedStatus.class.php
@@ -23,9 +23,7 @@ class UnexpectedStatus extends IllegalStateException {
    * @return var
    */
   public function reason($type= null) {
-    return $this->response->format() instanceof Unsupported
-      ? $this->response->content()
-      : $this->response->value($type ?? 'var')
-    ;
+    $r= $this->response->reader();
+    return $r->format() instanceof Unsupported ? $r->content() : $r->read($type ?? 'var');
   }
 }

--- a/src/main/php/webservices/rest/io/Reader.class.php
+++ b/src/main/php/webservices/rest/io/Reader.class.php
@@ -19,6 +19,29 @@ class Reader {
   /** @return io.streams.InputStream */
   public function stream() { return $this->stream; }
 
+  /**
+   * Reads the payload as a string
+   *
+   * @return string
+   */
+  public function content() {
+    try {
+      $r= '';
+      while ($this->stream->available()) {
+        $r.= $this->stream->read();
+      }
+      return $r;
+    } finally {
+      $this->stream->close();
+    }
+  }
+
+  /**
+   * Reads the payload and unmarshals it to data
+   *
+   * @param  string $type
+   * @return var
+   */
   public function read($type= 'var') {
     return $this->marshalling->unmarshal($this->format->deserialize($this->stream), $type);
   }

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -10,6 +10,7 @@ use webservices\rest\io\Reader;
 use webservices\rest\{Cookie, Cookies, Link, RestResponse};
 
 class RestResponseTest extends TestCase {
+  const API = 'https://api.example.com/';
 
   #[Test]
   public function can_create() {
@@ -52,6 +53,14 @@ class RestResponseTest extends TestCase {
     $this->assertEquals(
       new URI('http://example.com/'),
       (new RestResponse(200, 'OK', [], null, 'http://example.com/'))->uri()
+    );
+  }
+
+  #[Test, Values([[null, 'http://example.com/test/'], [self::API, self::API], ['/', 'http://example.com/'], ['/user/', 'http://example.com/user/']])]
+  public function resolve_uri($uri, $resolved) {
+    $this->assertEquals(
+      new URI($resolved),
+      (new RestResponse(200, 'OK', [], null, 'http://example.com/test/'))->resolve($uri)
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -43,6 +43,14 @@ class RestResponseTest extends TestCase {
   }
 
   #[Test]
+  public function uri() {
+    $this->assertEquals(
+      new URI('http://example.com/'),
+      (new RestResponse(200, 'OK', [], null, 'http://example.com/'))->uri()
+    );
+  }
+
+  #[Test]
   public function stream() {
     $stream= new MemoryInputStream('...');
     $reader= new Reader($stream, new Json(), new Marshalling());

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -43,6 +43,11 @@ class RestResponseTest extends TestCase {
   }
 
   #[Test]
+  public function no_uri() {
+    $this->assertNull((new RestResponse(200, 'OK'))->uri());
+  }
+
+  #[Test]
   public function uri() {
     $this->assertEquals(
       new URI('http://example.com/'),


### PR DESCRIPTION
This pull request marks the following methods on `webservices.rest.RestResponse` as deprecated and finishes the separation between lower-level functionality in this class and higher-level abstractions in `webservices.rest.Result`, see #14 

### values()
```php
// Now deprecated:
$value= $response->value();

// For most cases, this is correct (and now includes error handling)!
$value= $response->result()->value();

// A real replacement
$value= $response->reader()->read(); 
```

### location()
```php
// Now deprecated:
$location= $response->location();

// For most cases, this is correct (and now includes error handling)!
$location= $response->result()->location();

// A real replacement
$location= $response->resolve($response->header('Location'));
```

### links()
```php
// Now deprecated:
$next= $response->links()->uri(['rel' => 'next']);

// For most cases, this is correct (and now includes error handling)!
$next= $response->result()->link('next');

// A real replacement
$next= Links::in($response->header('Link'))->uri(['rel' => 'next']);

// Now deprecated:
$links= $response->links();

// If you want links mapped by the "rel" attribute, you can use this:
$links= $response->result()->links();

// A real replacement
$links= Links::in($response->header('Link'));
```