### PR TITLE
Add support for bearer tokens embedded directly in base URI

### DIFF
--- a/src/test/php/webservices/rest/unittest/EndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/EndpointTest.class.php
@@ -63,4 +63,33 @@ class EndpointTest {
   public function execute_given_illegal_argument() {
     $this->newFixture()->execute(null);
   }
+
+  #[Test, Expect(IllegalArgumentException::class), Values(['/api/v1', 'mailto:thekid@example.com'])]
+  public function cannot_be_constructed_with($uri) {
+    $this->newFixture($uri);
+  }
+
+  #[Test]
+  public function supports_basic_auth() {
+    Assert::equals(
+      ['Authorization' => 'Basic dXNlcjpwYXNz'],
+      $this->newFixture('https://user:pass@example.org/')->headers()
+    );
+  }
+
+  #[Test]
+  public function supports_bearer_token() {
+    Assert::equals(
+      ['Authorization' => 'Bearer JWT'],
+      $this->newFixture('https://JWT@example.org/')->headers()
+    );
+  }
+
+  #[Test, Values(['user:pass', 'token'])]
+  public function credentials_not_included_in_base($credentials) {
+    Assert::equals(
+      new URI('https://example.org/'),
+      $this->newFixture("https://${credentials}@example.org/")->base()
+    );
+  }
 }

--- a/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
@@ -12,8 +12,8 @@ use webservices\rest\{Endpoint, RestException, RestUpload};
 class ExecuteTest {
 
   /** Returns a new endpoint using the `TestConnection` class */
-  private function newFixture() {
-    return (new Endpoint('http://test'))->connecting([TestConnection::class, 'new']);
+  private function newFixture(string $base= 'http://test') {
+    return (new Endpoint($base))->connecting([TestConnection::class, 'new']);
   }
 
   /** Returns a log appender which stores formatted lines */
@@ -338,6 +338,24 @@ class ExecuteTest {
       "\r\n".
       "{\"test\":true}",
       $resource->post(['test' => true], 'application/json')->content()
+    );
+  }
+
+  #[Test]
+  public function passes_basic_auth() {
+    $resource= $this->newFixture('http://user:pass@test')->resource('/test');
+    Assert::equals(
+      "GET /test HTTP/1.1\r\nConnection: close\r\nHost: test\r\nAuthorization: Basic dXNlcjpwYXNz\r\n\r\n",
+      $resource->get()->content()
+    );
+  }
+
+  #[Test]
+  public function passes_bearer_token() {
+    $resource= $this->newFixture('http://JWT@test')->resource('/test');
+    Assert::equals(
+      "GET /test HTTP/1.1\r\nConnection: close\r\nHost: test\r\nAuthorization: Bearer JWT\r\n\r\n",
+      $resource->get()->content()
     );
   }
 }


### PR DESCRIPTION
## Examples

URIs passed to the `webservices.rest.Endpoint` constructor may include credentials.

```php
use webservices\rest\Endpoint;

// Without credentials, no Authorization header
new Endpoint('https://example.org/api/v1');

// With basic authentication, Authorization: Basic `base64(user:pass)`
new Endpoint('https://user:pass@example.org/api/v1');
```

This pull requests implements resolving a username *without* password to a bearer token:

```php
// Passing a bearer token, Authorization: Bearer token
new Endpoint('https://token@example.org/api/v1');
```

Other authorization headers are passed manually:

```php
(new Endpoint('https://example.org/api/v1'))->with('Authorization', '...');
```

## Benefits

This greatly simplifies code like this:

```php
class Api {
  private $endpoint;

  /** Creates a new instance with a URI of the form `[https?]://[JWT]@[host][path]` */
  public function __construct(string $uri) {
    $u= parse_url($uri);
    $base= $u['scheme'].'://'.$u['host'].(isset($u['port']) ? ':'.$u['port'] : '').($u['path'] ?? '/');
    $this->endpoint= (new Endpoint($base))->with(['Authorization' => 'Bearer '.$u['user']]);
  }
}
```

The above can now be rewritten to the following straight-forward form:

```php
class Api {
  private $endpoint;

  /** Creates a new instance with a URI of the form `[https?]://[JWT]@[host][path]` */
  public function __construct(string $uri) {
    $this->endpoint= new Endpoint($uri);
  }
}
```

* * * 

See also:
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
* https://blog.risingstack.com/web-authentication-methods-explained/
* https://blog.restcase.com/4-most-used-rest-api-authentication-methods/
* https://www.oauth.com/oauth2-servers/differences-between-oauth-1-2/bearer-tokens/