### PR TITLE
Testability

### DIFF
--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -14,7 +14,7 @@ use webservices\rest\io\{Buffered, Reader, Streamed, Traced, Transmission};
  * @test  xp://webservices.rest.unittest.EndpointTest
  */
 class Endpoint implements Traceable {
-  private $base, $formats, $transfer, $marshalling;
+  protected $base, $formats, $transfer, $marshalling;
   private $headers= [];
   private $cat= null;
 

--- a/src/main/php/webservices/rest/TestCall.class.php
+++ b/src/main/php/webservices/rest/TestCall.class.php
@@ -1,8 +1,8 @@
 <?php namespace webservices\rest;
 
-use webservices\rest\io\{Reader, Transmission};
 use io\streams\{InputStream, MemoryInputStream};
 use util\data\Marshalling;
+use webservices\rest\io\{Reader, Transmission};
 
 class TestCall extends Transmission {
   private $formats, $marshalling;
@@ -48,7 +48,7 @@ class TestCall extends Transmission {
    * @param  string|io.streams.InputStream $payload
    * @return webservices.rest.RestResponse
    */
-  public function respond($status, $message, $headers= [], $payload= null): RestResponse {
+  public function respond($status, $message, $headers= [], $payload= ''): RestResponse {
     return new RestResponse($status, $message, $headers, new Reader(
       $payload instanceof InputStream ? $payload : new MemoryInputStream($payload),
       $this->formats->named($headers['Content-Type'] ?? null),

--- a/src/main/php/webservices/rest/TestCall.class.php
+++ b/src/main/php/webservices/rest/TestCall.class.php
@@ -1,0 +1,36 @@
+<?php namespace webservices\rest;
+
+use webservices\rest\io\Reader;
+use io\streams\{InputStream, MemoryInputStream};
+use util\data\Marshalling;
+
+class TestCall {
+  private $request, $formats, $marshalling;
+
+  /** Creates a new call */
+  public function __construct(RestRequest $request, Formats $formats, Marshalling $marshalling= null) {
+    $this->request= $request;
+    $this->formats= $formats;
+    $this->marshalling= $marshalling ?? new Marshalling();
+  }
+
+  /** Returns the request associated with this call */
+  public function request(): RestRequest { return $this->request; }
+
+  /**
+   * Responds to this call with a given status call, message, headers and payload.
+   *
+   * @param  int $status
+   * @param  string $message
+   * @param  [:string] $headers
+   * @param  string|io.streams.InputStream $payload
+   * @return webservices.rest.RestResponse
+   */
+  public function respond($status, $message, $headers= [], $payload= null): RestResponse {
+    return new RestResponse($status, $message, $headers, new Reader(
+      $payload instanceof InputStream ? $payload : new MemoryInputStream($payload),
+      $this->formats->named($headers['Content-Type'] ?? null),
+      $this->marshalling
+    ));
+  }
+}

--- a/src/main/php/webservices/rest/TestCall.class.php
+++ b/src/main/php/webservices/rest/TestCall.class.php
@@ -1,11 +1,12 @@
 <?php namespace webservices\rest;
 
-use webservices\rest\io\Reader;
+use webservices\rest\io\{Reader, Transmission};
 use io\streams\{InputStream, MemoryInputStream};
 use util\data\Marshalling;
 
-class TestCall {
-  private $request, $formats, $marshalling;
+class TestCall extends Transmission {
+  private $formats, $marshalling;
+  public $transfer= null;
 
   /** Creates a new call */
   public function __construct(RestRequest $request, Formats $formats, Marshalling $marshalling= null) {
@@ -16,6 +17,27 @@ class TestCall {
 
   /** Returns the request associated with this call */
   public function request(): RestRequest { return $this->request; }
+
+  /**
+   * Writes given bytes
+   *
+   * @param  string $bytes
+   * @return int
+   */
+  public function write($bytes) {
+    $this->transfer.= $bytes;
+    return strlen($bytes);
+  }
+
+  /** @return void */
+  public function flush() {
+    // NOOP
+  }
+
+  /** @return void */
+  public function close() {
+    // NOOP
+  }
 
   /**
    * Responds to this call with a given status call, message, headers and payload.

--- a/src/main/php/webservices/rest/TestEndpoint.class.php
+++ b/src/main/php/webservices/rest/TestEndpoint.class.php
@@ -17,15 +17,16 @@ use webservices\rest\io\Transmission;
  * @test  webservices.rest.unittest.TestEndpointTest
  */
 class TestEndpoint extends Endpoint {
-  private $routes= [];
+  private $routes;
 
   /**
    * Creates a new testing endpoint
    *
-   * @param  [:function(webservices.rest.TestCall): webservices.rest.RestResponse]
+   * @param  [:function(webservices.rest.TestCall): webservices.rest.RestResponse] $routes
+   * @param  string $base
    */
-  public function __construct(array $routes) {
-    parent::__construct('http://test.local', Formats::defaults());
+  public function __construct(array $routes, $base= '/') {
+    parent::__construct('http://test.local/'.ltrim($base, '/'), Formats::defaults());
     $this->routes= $routes;
   }
 
@@ -37,8 +38,9 @@ class TestEndpoint extends Endpoint {
    */
   private function handle($call) {
     $request= $call->request();
-    $handler= $this->routes[$request->method().' '.$request->path()]
-      ?? $this->routes[$request->path()]
+    $resolved= $this->base->resolve($request->path())->path();
+    $handler= $this->routes[$request->method().' '.$resolved]
+      ?? $this->routes[$resolved]
       ?? function() { return new RestResponse(404, 'No route', []); }
     ;
 

--- a/src/main/php/webservices/rest/TestEndpoint.class.php
+++ b/src/main/php/webservices/rest/TestEndpoint.class.php
@@ -3,13 +3,20 @@
 use webservices\rest\io\Transmission;
 
 /**
- * Endpoint subclass used for testing REST clients.
+ * Endpoint subclass used for testing REST clients. Accepts a map of routes
+ * using absolute paths, optionally prefixed with an HTTP method, as such:
  *
  * ```php
- * $endpoint= new TestEndpoint([
- *  '/users/me' => function($call) {
- *    return $call->respond(307, 'Temporary Redirect', ['Location' => '/users/6100']);
- *   }
+ * new TestEndpoint([
+ *   '/users/6100' => function($call) {
+ *     return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], '{
+ *       "id": 6100,
+ *       "username": "binford"
+ *     }');
+ *   },
+ *   'POST /users' => function($call) {
+ *     return $call->respond(201, 'Created', ['Location' => '/users/6100']);
+ *   },
  * ]);
  * ```
  *

--- a/src/main/php/webservices/rest/TestEndpoint.class.php
+++ b/src/main/php/webservices/rest/TestEndpoint.class.php
@@ -2,7 +2,7 @@
 
 /**
  * Endpoint subclass used for testing REST clients.
- * 
+ *
  * ```php
  * $endpoint= new TestEndpoint([
  *  '/users/me' => function($call) {
@@ -10,7 +10,7 @@
  *   }
  * ]);
  * ```
- * 
+ *
  * @see   webservices.rest.TestCall
  * @test  webservices.rest.unittest.TestEndpointTest
  */
@@ -19,7 +19,7 @@ class TestEndpoint extends Endpoint {
 
   /**
    * Creates a new testing endpoint
-   * 
+   *
    * @param  [:function(webservices.rest.TestCall): webservices.rest.RestResponse]
    */
   public function __construct(array $routes) {
@@ -39,7 +39,7 @@ class TestEndpoint extends Endpoint {
       ?? $this->routes[$req->path()]
       ?? function() { return new RestResponse(404, 'No route', []); }
     ;
-    
+
     return $handler(new TestCall($req, $this->formats, $this->marshalling));
   }
 }

--- a/src/main/php/webservices/rest/TestEndpoint.class.php
+++ b/src/main/php/webservices/rest/TestEndpoint.class.php
@@ -1,0 +1,45 @@
+<?php namespace webservices\rest;
+
+/**
+ * Endpoint subclass used for testing REST clients.
+ * 
+ * ```php
+ * $endpoint= new TestEndpoint([
+ *  '/users/me' => function($call) {
+ *    return $call->respond(307, 'Temporary Redirect', ['Location' => '/users/6100']);
+ *   }
+ * ]);
+ * ```
+ * 
+ * @see   webservices.rest.TestCall
+ * @test  webservices.rest.unittest.TestEndpointTest
+ */
+class TestEndpoint extends Endpoint {
+  private $routes= [];
+
+  /**
+   * Creates a new testing endpoint
+   * 
+   * @param  [:function(webservices.rest.TestCall): webservices.rest.RestResponse]
+   */
+  public function __construct(array $routes) {
+    parent::__construct('http://test.local', Formats::defaults());
+    $this->routes= $routes;
+  }
+
+  /**
+   * Sends a request and returns the response
+   *
+   * @param  webservices.rest.RestRequest $request
+   * @return webservices.rest.RestResponse
+   * @throws webservices.rest.RestException
+   */
+  public function execute(RestRequest $req) {
+    $handler= $this->routes[$req->method().' '.$req->path()]
+      ?? $this->routes[$req->path()]
+      ?? function() { return new RestResponse(404, 'No route', []); }
+    ;
+    
+    return $handler(new TestCall($req, $this->formats, $this->marshalling));
+  }
+}

--- a/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace webservices\rest\unittest;
 
+use io\streams\MemoryInputStream;
 use unittest\{Assert, Test};
 use webservices\rest\{TestEndpoint, RestResponse};
 
@@ -37,6 +38,21 @@ class TestEndpointTest {
 
     Assert::equals(200, $r->status());
     Assert::equals(['id' => 6100, 'handle' => 'test'], $r->value());
+  }
+
+  #[Test]
+  public function routed_path_with_upload() {
+    $fixture= new TestEndpoint([
+      '/users/6100/picture' => function($call) {
+        return $call->respond(202, 'Accepted');
+      }
+    ]);
+    $r= $fixture->resource('/users/6100/picture')->upload()
+      ->transfer('picture', new MemoryInputStream('...'), 'image.jpg')
+      ->finish()
+    ;
+
+    Assert::equals(202, $r->status());
   }
 
   #[Test]

--- a/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace webservices\rest\unittest;
 
 use io\streams\MemoryInputStream;
-use unittest\{Assert, Test};
+use unittest\{Assert, Test, Values};
 use webservices\rest\{TestEndpoint, RestResponse};
 
 class TestEndpointTest {
@@ -11,17 +11,30 @@ class TestEndpointTest {
     new TestEndpoint([]);
   }
 
-  #[Test]
-  public function routed_path() {
+  #[Test, Values(['/users/self', 'users/self'])]
+  public function routed_path($resource) {
     $fixture= new TestEndpoint([
       '/users/self' => function($call) {
         return $call->respond(307, 'Temporary Redirect', ['Location' => '/users/6100']);
       }
     ]);
-    $r= $fixture->resource('/users/self')->get();
+    $r= $fixture->resource($resource)->get();
 
     Assert::equals(307, $r->status());
     Assert::equals('/users/6100', $r->header('Location'));
+  }
+
+  #[Test, Values(['/api/users/self', 'users/self'])]
+  public function routed_path_under_base($resource) {
+    $fixture= new TestEndpoint([
+      '/api/users/self' => function($call) {
+        return $call->respond(307, 'Temporary Redirect', ['Location' => '/api/users/6100']);
+      }
+    ], '/api');
+    $r= $fixture->resource($resource)->get();
+
+    Assert::equals(307, $r->status());
+    Assert::equals('/api/users/6100', $r->header('Location'));
   }
 
   #[Test]

--- a/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
@@ -1,0 +1,60 @@
+<?php namespace webservices\rest\unittest;
+
+use unittest\{Assert, Test};
+use webservices\rest\{TestEndpoint, RestResponse};
+
+class TestEndpointTest {
+
+  #[Test]
+  public function can_create() {
+    new TestEndpoint([]);
+  }
+
+  #[Test]
+  public function routed_path() {
+    $fixture= new TestEndpoint([
+      '/user/self' => function($call) {
+        return $call->respond(307, 'Temporary Redirect', ['Location' => '/user/6100']);
+      }
+    ]);
+    $r= $fixture->resource('/user/self')->get();
+
+    Assert::equals(307, $r->status());
+    Assert::equals('/user/6100', $r->header('Location'));
+  }
+
+  #[Test]
+  public function routed_path_with_content() {
+    $fixture= new TestEndpoint([
+      '/user/6100' => function($call) {
+        return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], '{
+          "id": 6100,
+          "handle": "test"
+        }');
+      }
+    ]);
+    $r= $fixture->resource('/user/6100')->get();
+
+    Assert::equals(200, $r->status());
+    Assert::equals(['id' => 6100, 'handle' => 'test'], $r->value());
+  }
+
+  #[Test]
+  public function routed_path_with_method() {
+    $fixture= new TestEndpoint([
+      'DELETE /user/1' => function($call) {
+        return $call->respond(204, 'No content');
+      }
+    ]);
+    $r= $fixture->resource('/user/1')->delete();
+
+    Assert::equals(204, $r->status());
+    Assert::equals('', $r->content());
+  }
+
+  #[Test]
+  public function yields_404_for_unrouted_paths() {
+    $fixture= new TestEndpoint([]);
+    Assert::equals(404, $fixture->resource('/')->get()->status());
+  }
+}

--- a/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
@@ -13,27 +13,27 @@ class TestEndpointTest {
   #[Test]
   public function routed_path() {
     $fixture= new TestEndpoint([
-      '/user/self' => function($call) {
-        return $call->respond(307, 'Temporary Redirect', ['Location' => '/user/6100']);
+      '/users/self' => function($call) {
+        return $call->respond(307, 'Temporary Redirect', ['Location' => '/users/6100']);
       }
     ]);
-    $r= $fixture->resource('/user/self')->get();
+    $r= $fixture->resource('/users/self')->get();
 
     Assert::equals(307, $r->status());
-    Assert::equals('/user/6100', $r->header('Location'));
+    Assert::equals('/users/6100', $r->header('Location'));
   }
 
   #[Test]
   public function routed_path_with_content() {
     $fixture= new TestEndpoint([
-      '/user/6100' => function($call) {
+      '/users/6100' => function($call) {
         return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], '{
           "id": 6100,
           "handle": "test"
         }');
       }
     ]);
-    $r= $fixture->resource('/user/6100')->get();
+    $r= $fixture->resource('/users/6100')->get();
 
     Assert::equals(200, $r->status());
     Assert::equals(['id' => 6100, 'handle' => 'test'], $r->value());
@@ -42,11 +42,11 @@ class TestEndpointTest {
   #[Test]
   public function routed_path_with_method() {
     $fixture= new TestEndpoint([
-      'DELETE /user/1' => function($call) {
+      'DELETE /users/1' => function($call) {
         return $call->respond(204, 'No content');
       }
     ]);
-    $r= $fixture->resource('/user/1')->delete();
+    $r= $fixture->resource('/users/1')->delete();
 
     Assert::equals(204, $r->status());
     Assert::equals('', $r->content());


### PR DESCRIPTION
This pull request adds a `TestEndpoint` class which can be used for testing purposes. This is in line with the `TestInput` and `TestOutput` classes from *xp-forge/web* especially designed for these usecases.

## Example

```php
use webservices\rest\TestEndpoint;

$endpoint= new TestEndpoint([
  '/users/6100' => function($call) {
    return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], '{
      "id": 6100,
      "username": "binford"
    }');
  },
  'POST /users' => function($call) {
    return $call->respond(201, 'Created', ['Location' => '/users/6100']);
  },
]);

$response= $endpoint->resource('/users/me')->get();
// Responds with HTTP status 200 and the above JSON payload
```
