### PR TITLE
Compression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "xp-forge/json": "^5.0 | ^4.0 | ^3.1",
     "xp-forge/uri": "^2.0 | ^1.3",
     "xp-forge/marshalling": "^1.0",
+    "xp-forge/compress": "^0.2",
     "php": ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "xp-forge/json": "^5.0 | ^4.0 | ^3.1",
     "xp-forge/uri": "^2.0 | ^1.3",
     "xp-forge/marshalling": "^1.0",
-    "xp-forge/compression": "^0.2",
+    "xp-forge/compression": "^0.3",
     "php": ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "xp-forge/json": "^5.0 | ^4.0 | ^3.1",
     "xp-forge/uri": "^2.0 | ^1.3",
     "xp-forge/marshalling": "^1.0",
-    "xp-forge/compress": "^0.2",
+    "xp-forge/compression": "^0.2",
     "php": ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -76,20 +76,27 @@ class Endpoint implements Traceable {
 
   /**
    * Signal support compression algorithms in the "Accept-Encoding" header.
-   * Pass an empty iterable will remove the header alltogether.
+   * Calling without arguments will use the 
    *
-   * @param  ?iterable $algorithms If omitted, detects support algorithms
+   * @param  (string|io.streams.compress.Algorithm)... $algorithms
    * @return self
    */
-  public function compressing($algorithms= null) {
+  public function compressing(...$algorithms) {
     $supported= [];
-    if (null === $algorithms) {
+
+    if (empty($algorithms)) {
       foreach (Compression::algorithms()->supported() as $algorithm) {
         $supported[]= $algorithm->token();
       }
     } else {
       foreach ($algorithms as $algorithm) {
-        $supported[]= $algorithm instanceof Algorithm ? $algorithm->token() : (string)$algorithm;
+        if (null === $algorithm) {
+          // Skip
+        } else if ($algorithm instanceof Algorithm) {
+          $supported[]= $algorithm->token();
+        } else {
+          $supported[]= (string)$algorithm;
+        }
       }
     }
 

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -76,9 +76,10 @@ class Endpoint implements Traceable {
 
   /**
    * Signal support compression algorithms in the "Accept-Encoding" header.
-   * Calling without arguments will use the 
+   * Calling without arguments will detect algorithms supported in this
+   * runtime setup.
    *
-   * @param  (string|io.streams.compress.Algorithm)... $algorithms
+   * @param  (?string|io.streams.compress.Algorithm)... $algorithms
    * @return self
    */
   public function compressing(...$algorithms) {

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -1,5 +1,6 @@
 <?php namespace webservices\rest;
 
+use io\streams\Compression;
 use lang\{Throwable, IllegalArgumentException};
 use peer\URL;
 use peer\http\{HttpConnection, HttpRequest};
@@ -69,6 +70,27 @@ class Endpoint implements Traceable {
    */
   public function buffered() {
     $this->transfer= new Buffered($this);
+    return $this;
+  }
+
+  /**
+   * Signal support compression algorithms in the "Accept-Encoding" header.
+   * Pass an empty iterable will remove the header alltogether.
+   *
+   * @param  ?iterable $algorithms If omitted, detects support algorithms
+   * @return self
+   */
+  public function compressing($algorithms= null) {
+    $supported= [];
+    foreach ($algorithms ?? Compression::algorithms()->supported() as $algorithm) {
+      $supported[]= $algorithm->token();
+    }
+
+    if (empty($supported)) {
+      unset($this->headers['Accept-Encoding']);
+    } else {
+      $this->headers['Accept-Encoding']= implode(', ', $supported);
+    }
     return $this;
   }
 

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -1,6 +1,7 @@
 <?php namespace webservices\rest;
 
 use io\streams\Compression;
+use io\streams\compress\Algorithm;
 use lang\{Throwable, IllegalArgumentException};
 use peer\URL;
 use peer\http\{HttpConnection, HttpRequest};
@@ -82,8 +83,14 @@ class Endpoint implements Traceable {
    */
   public function compressing($algorithms= null) {
     $supported= [];
-    foreach ($algorithms ?? Compression::algorithms()->supported() as $algorithm) {
-      $supported[]= $algorithm->token();
+    if (null === $algorithms) {
+      foreach (Compression::algorithms()->supported() as $algorithm) {
+        $supported[]= $algorithm->token();
+      }
+    } else {
+      foreach ($algorithms as $algorithm) {
+        $supported[]= $algorithm instanceof Algorithm ? $algorithm->token() : (string)$algorithm;
+      }
     }
 
     if (empty($supported)) {

--- a/src/main/php/webservices/rest/io/Transfer.class.php
+++ b/src/main/php/webservices/rest/io/Transfer.class.php
@@ -1,10 +1,12 @@
 <?php namespace webservices\rest\io;
 
+use io\streams\Compression;
 use lang\MethodNotImplementedException;
 
 abstract class Transfer {
   protected $endpoint;
 
+  /** @param webservices.rest.Endpoint */
   public function __construct($endpoint) { $this->endpoint= $endpoint; }
 
   /** @return self */
@@ -33,6 +35,12 @@ abstract class Transfer {
   }
 
   public function reader($response, $format, $marshalling) {
-    return new Reader($response->in(), $format, $marshalling);
+    if ($encoding= $response->header('Content-Encoding')) {
+      $in= Compression::named($encoding[0])->open($response->in());
+    } else {
+      $in= $response->in();
+    }
+
+    return new Reader($in, $format, $marshalling);
   }
 }

--- a/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
@@ -49,6 +49,13 @@ class CompressionHandlingTest {
   }
 
   #[Test]
+  public function do_not_use_compression() {
+    $this->endpoint->compressing(['identity']);
+
+    Assert::equals('identity', $this->endpoint->headers()['Accept-Encoding']);
+  }
+
+  #[Test]
   public function removes_accept_encoding_header() {
     $this->endpoint->compressing([]);
 

--- a/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace webservices\rest\unittest;
 
 use io\streams\MemoryInputStream;
+use io\streams\compress\{Gzip, Brotli};
 use peer\http\HttpResponse;
 use unittest\actions\ExtensionAvailable;
 use unittest\{Action, Assert, Before, Test, Values};
@@ -38,6 +39,20 @@ class CompressionHandlingTest {
   #[Before]
   public function endpoint() {
     $this->endpoint= new Endpoint('http://api.example.com');
+  }
+
+  #[Test]
+  public function sets_accept_encoding_header() {
+    $this->endpoint->compressing([new Gzip(), new Brotli()]);
+
+    Assert::equals('gzip, br', $this->endpoint->headers()['Accept-Encoding']);
+  }
+
+  #[Test]
+  public function removes_accept_encoding_header() {
+    $this->endpoint->compressing([]);
+
+    Assert::false(isset($this->endpoint->headers()['Accept-Encoding']));
   }
 
   #[Test, Values([1, 6, 9]), Action(eval: 'new ExtensionAvailable("zlib")')]

--- a/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace webservices\rest\unittest;
 
-use io\streams\MemoryInputStream;
-use io\streams\compress\{Gzip, Brotli};
+use io\streams\{Compression, MemoryInputStream};
 use peer\http\HttpResponse;
 use unittest\actions\ExtensionAvailable;
 use unittest\{Action, Assert, Before, Test, Values};
@@ -41,16 +40,26 @@ class CompressionHandlingTest {
     $this->endpoint= new Endpoint('http://api.example.com');
   }
 
+  #[Test, Action(eval: 'new ExtensionAvailable("zlib")')]
+  public function accept_includes_gzip() {
+    Assert::notEquals('', strstr($this->endpoint->headers()['Accept-Encoding'], 'gzip'));
+  }
+
+  #[Test, Action(eval: 'new ExtensionAvailable("brotli")')]
+  public function accept_includes_brotli() {
+    Assert::notEquals('', strstr($this->endpoint->headers()['Accept-Encoding'], 'br'));
+  }
+
   #[Test]
   public function sets_accept_encoding_header() {
-    $this->endpoint->compressing(new Gzip(), new Brotli());
+    $this->endpoint->compressing(['gzip', 'br']);
 
     Assert::equals('gzip, br', $this->endpoint->headers()['Accept-Encoding']);
   }
 
   #[Test]
   public function do_not_use_compression() {
-    $this->endpoint->compressing('identity');
+    $this->endpoint->compressing(Compression::$NONE);
 
     Assert::equals('identity', $this->endpoint->headers()['Accept-Encoding']);
   }

--- a/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
@@ -1,0 +1,60 @@
+<?php namespace webservices\rest\unittest;
+
+use io\streams\MemoryInputStream;
+use peer\http\HttpResponse;
+use unittest\actions\ExtensionAvailable;
+use unittest\{Action, Assert, Before, Test, Values};
+use webservices\rest\Endpoint;
+use webservices\rest\io\Transmission;
+
+class CompressionHandlingTest {
+  private $endpoint;
+
+  /**
+   * Creates a HTTP response with status 200 from given headers and payload
+   *
+   * @param  [:string] $headers
+   * @param  string $payload
+   * @return webservices.rest.RestResponse
+   */
+  private function response($headers, $payload) {
+    return $this->endpoint->finish(new class($headers, $payload) extends Transmission {
+      private $body;
+
+      public function __construct($headers, $payload) {
+        $this->body= "HTTP/1.1 200 OK\r\nContent-Length: ".strlen($payload)."\r\n";
+        foreach ($headers as $name => $value) {
+          $this->body.= $name.': '.$value."\r\n";
+        }
+        $this->body.= "\r\n".$payload;
+      }
+
+      public function finish() {
+        return new HttpResponse(new MemoryInputStream($this->body), false);
+      }
+    });
+  }
+
+  #[Before]
+  public function endpoint() {
+    $this->endpoint= new Endpoint('http://api.example.com');
+  }
+
+  #[Test, Values([1, 6, 9]), Action(eval: 'new ExtensionAvailable("zlib")')]
+  public function gzip($level) {
+    $response= $this->response(
+      ['Content-Type' => 'application/json', 'Content-Encoding' => 'gzip'],
+      gzencode('{"result":true}', $level)
+    );
+    Assert::equals(['result' => true], $response->value());
+  }
+
+  #[Test, Values([0, 6, 11]), Action(eval: 'new ExtensionAvailable("brotli")')]
+  public function brotli($level) {
+    $response= $this->response(
+      ['Content-Type' => 'application/json', 'Content-Encoding' => 'br'],
+      brotli_compress('{"result":true}', $level)
+    );
+    Assert::equals(['result' => true], $response->value());
+  }
+}

--- a/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
@@ -43,21 +43,21 @@ class CompressionHandlingTest {
 
   #[Test]
   public function sets_accept_encoding_header() {
-    $this->endpoint->compressing([new Gzip(), new Brotli()]);
+    $this->endpoint->compressing(new Gzip(), new Brotli());
 
     Assert::equals('gzip, br', $this->endpoint->headers()['Accept-Encoding']);
   }
 
   #[Test]
   public function do_not_use_compression() {
-    $this->endpoint->compressing(['identity']);
+    $this->endpoint->compressing('identity');
 
     Assert::equals('identity', $this->endpoint->headers()['Accept-Encoding']);
   }
 
   #[Test]
   public function removes_accept_encoding_header() {
-    $this->endpoint->compressing([]);
+    $this->endpoint->compressing(null);
 
     Assert::false(isset($this->endpoint->headers()['Accept-Encoding']));
   }

--- a/src/test/php/webservices/rest/unittest/EndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/EndpointTest.class.php
@@ -16,7 +16,7 @@ class EndpointTest {
    * @return web.rest.Endpoint
    */
   private function newFixture($base= self::BASE_URL) {
-    return new Endpoint($base);
+    return new Endpoint($base, null, []);
   }
 
   #[Test, Values(eval: '[self::BASE_URL, new URI(self::BASE_URL), new URL(self::BASE_URL)]')]

--- a/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
@@ -13,7 +13,7 @@ class ExecuteTest {
 
   /** Returns a new endpoint using the `TestConnection` class */
   private function newFixture(string $base= 'http://test') {
-    return (new Endpoint($base))->connecting([TestConnection::class, 'new']);
+    return (new Endpoint($base, null, []))->connecting([TestConnection::class, 'new']);
   }
 
   /** Returns a log appender which stores formatted lines */


### PR DESCRIPTION
This pull request implements the feature suggested in #21 using https://github.com/xp-forge/compression. 

## TL;DR

By default, you don't have to do anything. If your PHP setup supports compression (*Windows PHP comes with zlib enabled by default [1], Ubuntu's `php-cli` package's default configuration also includes it*), this library will signal it can handle it, and - should the server then decide to deliver compressed results - take care of uncompressing the results transparently.

## BC breaks

However, **if** you've been manually handling compression by adding an *Accept-Encoding* header using `with()` and looking at the *Content-Encoding* response header for reading compressed data, your code will stop working: `Response::stream()` will already return a compressed input stream, wrapping that inside another will not work. **The manual handling code will need to be removed when upgrading!**

* * * 

## Sending `Accept-Encoding`

Indicates the content encoding that the client can understand, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding. This can be accomplished as follows:

```php
use webservices\rest\Endpoint;
use io\streams\Compression;

// Detect supported compression algorithms and set "Accept-Encoding" accordingly
// This will typically yield "gzip", see above.
$endpoint= new Endpoint($api);

// Send "Accept-Encoding: identity", indicating the server should not compress
$endpoint= (new Endpoint($api))->compressing(Compression::$NONE);

// Send "Accept-Encoding: gzip, br"
$endpoint= (new Endpoint($api))->compressing(['gzip', 'br']);

// Do not send an "Accept-Encoding" header, i.e. no preference is expressed
// This is the same as the previous behavior
$endpoint= (new Endpoint($api))->compressing(null);
```

## Handling `Content-Encoding`

Indicates the content encoding that the server chose based on the above, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding. This header is handled automatically.

```php
use webservices\rest\Endpoint;

// Even though we don't set an "Accept-Encoding" header, the response may still
// be compressed - omitting it is the same as "*", or "anything is acceptable".
$endpoint= (new Endpoint($api))->compressing(null);
$stream= $endpoint->resource('...')->get();

// io.streams.compress.GzipInputStream instance for "Content-Encoding: gzip"
// io.streams.compress.BrotliInputStream instance for "Content-Encoding: br"
// peer.http.HttpInputStream for uncompressed responses
// 
// In any case, reading works exactly the same
while ($stream->available()) {
  $chunk= $stream->read();
}
```

1: https://www.php.net/manual/en/zlib.installation.php