### PR TITLE
Add possibility to modify read and connect timeouts

### DIFF
--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -3,7 +3,8 @@
 /**
  * REST request
  *
- * @test  xp://webservices.rest.unittest.RestRequestTest
+ * @test  webservices.rest.unittest.RestRequestTest
+ * @test  webservices.rest.unittest.TimeoutTest
  */
 class RestRequest {
   use Headers;
@@ -11,6 +12,7 @@ class RestRequest {
   private $method, $path, $cookies;
   private $parameters= [];
   private $payload= null;
+  private $timeouts= [null, null];
 
   /**
    * Creates a new REST request
@@ -41,6 +43,9 @@ class RestRequest {
 
   /** @return webservices.rest.Payload */
   public function payload() { return $this->payload; }
+
+  /** @return (?float)[] */
+  public function timeouts() { return $this->timeouts; }
 
   /**
    * Uses a given HTTP method
@@ -83,6 +88,18 @@ class RestRequest {
    */
   public function passing($parameters) {
     $this->parameters= $parameters;
+    return $this;
+  }
+
+  /**
+   * Sets timeouts for reading and connecting
+   *
+   * @param  ?float $read
+   * @param  ?float $connect
+   * @return self
+   */
+  public function waiting($read= null, $connect= null) {
+    $this->timeouts= [$read, $connect];
     return $this;
   }
 

--- a/src/main/php/webservices/rest/io/Transmission.class.php
+++ b/src/main/php/webservices/rest/io/Transmission.class.php
@@ -19,6 +19,9 @@ class Transmission implements OutputStream {
     $this->target= $target;
   }
 
+  /** @return peer.http.HttpConnection */
+  public function connection() { return $this->conn; }
+
   /** @return void */
   public function start() {
     $this->output= $this->conn->open($this->request);

--- a/src/test/php/webservices/rest/unittest/TimeoutTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TimeoutTest.class.php
@@ -1,0 +1,63 @@
+<?php namespace webservices\rest\unittest;
+
+use peer\http\HttpConnection;
+use unittest\{Assert, Before, Test};
+use webservices\rest\{Endpoint, RestRequest};
+
+class TimeoutTest {
+  const API = 'https://api.example.com';
+
+  private $endpoint, $conn;
+
+  #[Before]
+  public function endpoint() {
+    $this->endpoint= new Endpoint(self::API);
+    $this->conn= new HttpConnection(self::API);
+  }
+
+  #[Test]
+  public function takes_timeouts_from_httpconnection() {
+    $endpoint= (clone $this->endpoint)->connecting(function($uri) {
+      $c= new HttpConnection($uri);
+      $c->setTimeout(600);
+      $c->setConnectTimeout(30);
+      return $c;
+    });
+    $conn= $endpoint->open(new RestRequest('GET', '/'))->connection();
+
+    Assert::equals(600, $conn->getTimeout(), 'read');
+    Assert::equals(30, $conn->getConnectTimeout(), 'connect');
+  }
+
+  #[Test]
+  public function default_timeouts() {
+    $conn= $this->endpoint->open(new RestRequest('GET', '/'))->connection();
+
+    Assert::equals($this->conn->getTimeout(), $conn->getTimeout(), 'read');
+    Assert::equals($this->conn->getConnectTimeout(), $conn->getConnectTimeout(), 'connect');
+  }
+
+  #[Test]
+  public function change_read_timeout() {
+    $conn= $this->endpoint->open((new RestRequest('GET', '/'))->waiting(600, null))->connection();
+
+    Assert::equals(600, $conn->getTimeout(), 'read');
+    Assert::equals($this->conn->getConnectTimeout(), $conn->getConnectTimeout(), 'connect');
+  }
+
+  #[Test]
+  public function change_connect_timeout() {
+    $conn= $this->endpoint->open((new RestRequest('GET', '/'))->waiting(null, 30))->connection();
+
+    Assert::equals($this->conn->getTimeout(), $conn->getTimeout(), 'read');
+    Assert::equals(30, $conn->getConnectTimeout(), 'connect');
+  }
+
+  #[Test]
+  public function usage_via_resource_request_method() {
+    $conn= $this->endpoint->open($this->endpoint->resource('/')->request('GET')->waiting(600, 30))->connection();
+
+    Assert::equals(600, $conn->getTimeout(), 'read');
+    Assert::equals(30, $conn->getConnectTimeout(), 'connect');
+  }
+}


### PR DESCRIPTION
This pull request adds a *waiting()* method to the request API which allows setting read and connect timeouts. By default, these timeouts are derived from `peer.http.HttpConnection` and are set to:

* Connect: 2.0 seconds
* Read: 60.0 seconds

In some cases, certain invocations may take longer to execute. In these cases, the read timeout can be increased as follows:

```php
$endpoint= new Endpoint('https://api.example.com/v1');

// Execute with defaults
$response= $endpoint->resource('archive')->put();

// Open PUT request, set read timeout on it to 600 seconds, pass that to execute()
$response= $endpoint->execute($endpoint->resource('archive')->request('PUT')->waiting(read: 600));
```