### PR TITLE
Support segments in TestEndpoint routes

### DIFF
--- a/src/main/php/webservices/rest/TestEndpoint.class.php
+++ b/src/main/php/webservices/rest/TestEndpoint.class.php
@@ -49,9 +49,8 @@ class TestEndpoint extends Endpoint {
    */
   private function handle($call) {
     $request= $call->request();
-    $resolved= $this->base->resolve($request->path())->path();
 
-    $match= $request->method().' '.$resolved;
+    $match= $request->method().' '.$this->base->resolve($request->path())->path();
     foreach ($this->routes as $pattern => $handler) {
       if (preg_match($pattern, $match, $capture)) return $handler($call, $capture);
     }

--- a/src/main/php/webservices/rest/TestEndpoint.class.php
+++ b/src/main/php/webservices/rest/TestEndpoint.class.php
@@ -24,7 +24,7 @@ use webservices\rest\io\Transmission;
  * @test  webservices.rest.unittest.TestEndpointTest
  */
 class TestEndpoint extends Endpoint {
-  private $routes;
+  private $routes= [];
 
   /**
    * Creates a new testing endpoint
@@ -34,7 +34,11 @@ class TestEndpoint extends Endpoint {
    */
   public function __construct(array $routes, $base= '/') {
     parent::__construct('http://test.local/'.ltrim($base, '/'), Formats::defaults());
-    $this->routes= $routes;
+    foreach ($routes as $match => $handler) {
+      $p= strpos($match, ' ');
+      $s= preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $match);
+      $this->routes[false === $p ? '#.+ '.$s.'#' : '#'.$s.'#']= $handler;
+    }
   }
 
   /**
@@ -46,12 +50,13 @@ class TestEndpoint extends Endpoint {
   private function handle($call) {
     $request= $call->request();
     $resolved= $this->base->resolve($request->path())->path();
-    $handler= $this->routes[$request->method().' '.$resolved]
-      ?? $this->routes[$resolved]
-      ?? function() { return new RestResponse(404, 'No route', []); }
-    ;
 
-    return $handler($call);
+    $match= $request->method().' '.$resolved;
+    foreach ($this->routes as $pattern => $handler) {
+      if (preg_match($pattern, $match, $capture)) return $handler($call, $capture);
+    }
+
+    return new RestResponse(404, 'No route '.$match, []);
   }
 
   /**

--- a/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
@@ -86,7 +86,7 @@ class TestEndpointTest {
     $fixture= new TestEndpoint([
       '/users/{id}' => function($call, $segments) {
         return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], '{
-          "id": '.$segments['id'].',
+          "id": '.(int)$segments['id'].',
           "handle": "test"
         }');
       }

--- a/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
@@ -82,6 +82,22 @@ class TestEndpointTest {
   }
 
   #[Test]
+  public function routed_path_with_segment() {
+    $fixture= new TestEndpoint([
+      '/users/{id}' => function($call, $segments) {
+        return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], '{
+          "id": '.$segments['id'].',
+          "handle": "test"
+        }');
+      }
+    ]);
+    $r= $fixture->resource('/users/6100')->get();
+
+    Assert::equals(200, $r->status());
+    Assert::equals(['id' => 6100, 'handle' => 'test'], $r->value());
+  }
+
+  #[Test]
   public function yields_404_for_unrouted_paths() {
     $fixture= new TestEndpoint([]);
     Assert::equals(404, $fixture->resource('/')->get()->status());


### PR DESCRIPTION
This pull request adds support for placeholder segments in routes. These are embedded in the route URLs and enclosed in curly braces, e.g. `/users/{id}`.

## Example

```php
new TestEndpoint([
  '/users/{id}' => function($call, $segments) {
    return $call->respond(200, 'OK', ['Content-Type' => 'application/json'], '{
      "id": '.(int)$segments['id'].',
      "handle": "test"
    }');
  }
]);
```

The functionality is consistent with the routing in [xp-forge/rest-api](https://github.com/xp-forge/rest-api)