### PR TITLE
Add RestResource::uri()

### DIFF
--- a/src/main/php/webservices/rest/RestResource.class.php
+++ b/src/main/php/webservices/rest/RestResource.class.php
@@ -1,6 +1,7 @@
 <?php namespace webservices\rest;
 
 use lang\ElementNotFoundException;
+use util\URI;
 
 /**
  * A REST resource, consisting of path at a given endpoint; which can
@@ -55,6 +56,11 @@ class RestResource {
     } while ($offset < $l);
 
     return $target;
+  }
+
+  /** Returns target URI */
+  public function uri(): URI {
+    return $this->endpoint->base()->resolve($this->target);
   }
 
   /**

--- a/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\ElementNotFoundException;
 use unittest\{Assert, Expect, Test, Values};
+use util\URI;
 use webservices\rest\{Cookie, Cookies, Endpoint, RestRequest, RestResource, RestResponse};
 
 class RestResourceTest {
@@ -43,6 +44,22 @@ class RestResourceTest {
   #[Test, Expect(['class' => ElementNotFoundException::class, 'withMessage' => 'No such segment "id"'])]
   public function missing_segment_raises_error() {
     new RestResource($this->endpoint(), '/users/{id}');
+  }
+
+  #[Test]
+  public function uri() {
+    Assert::equals(
+      new URI('https://api.example.com/users'),
+      (new RestResource($this->endpoint(), '/users'))->uri()
+    );
+  }
+
+  #[Test]
+  public function uri_with_segments() {
+    Assert::equals(
+      new URI('https://api.example.com/users/6100/avatar/self'),
+      (new RestResource($this->endpoint(), '/users/{0}/avatar/{1}', [6100, 'self']))->uri()
+    );
   }
 
   #[Test]


### PR DESCRIPTION
This pull request adds a `uri()` method to fetch the resolved URI for a given resource.

```php
$endpoint= new Endpoint('https://api.example.com');
$resource= $endpoint->resource('/users/{0}/avatar/{1}', [6100, 'self']);

$resource->uri(); // util.URI<https://api.example.com/users/6100/avatar/self>
```