### PR TITLE
Migrate to new testing library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
     - name: Run test suite
       run: >
         curl --connect-timeout 3 --retry 3 --retry-delay 0 --retry-max-time 30 -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.6.2.sh > xp-run &&
-        sh xp-run xp.unittest.TestRunner src/test/php
+        sh xp-run xp.test.Runner src/test/php

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "php": ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^11.0 | ^10.0 | ^9.0 | ^8.0 |^7.0"
+    "xp-framework/test": "^1.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CompressionHandlingTest.class.php
@@ -2,8 +2,8 @@
 
 use io\streams\{Compression, MemoryInputStream};
 use peer\http\HttpResponse;
-use unittest\actions\ExtensionAvailable;
-use unittest\{Action, Assert, Before, Test, Values};
+use test\verify\Runtime;
+use test\{Action, Assert, Before, Test, Values};
 use webservices\rest\Endpoint;
 use webservices\rest\io\Transmission;
 
@@ -40,12 +40,12 @@ class CompressionHandlingTest {
     $this->endpoint= new Endpoint('http://api.example.com');
   }
 
-  #[Test, Action(eval: 'new ExtensionAvailable("zlib")')]
+  #[Test, Runtime(extensions: ['zlib'])]
   public function accept_includes_gzip() {
     Assert::notEquals('', strstr($this->endpoint->headers()['Accept-Encoding'], 'gzip'));
   }
 
-  #[Test, Action(eval: 'new ExtensionAvailable("brotli")')]
+  #[Test, Runtime(extensions: ['brotli'])]
   public function accept_includes_brotli() {
     Assert::notEquals('', strstr($this->endpoint->headers()['Accept-Encoding'], 'br'));
   }
@@ -71,7 +71,7 @@ class CompressionHandlingTest {
     Assert::false(isset($this->endpoint->headers()['Accept-Encoding']));
   }
 
-  #[Test, Values([1, 6, 9]), Action(eval: 'new ExtensionAvailable("zlib")')]
+  #[Test, Values([1, 6, 9]), Runtime(extensions: ['zlib'])]
   public function gzip($level) {
     $response= $this->response(
       ['Content-Type' => 'application/json', 'Content-Encoding' => 'gzip'],
@@ -80,7 +80,7 @@ class CompressionHandlingTest {
     Assert::equals(['result' => true], $response->value());
   }
 
-  #[Test, Values([0, 6, 11]), Action(eval: 'new ExtensionAvailable("brotli")')]
+  #[Test, Values([0, 6, 11]), Runtime(extensions: ['brotli'])]
   public function brotli($level) {
     $response= $this->response(
       ['Content-Type' => 'application/json', 'Content-Encoding' => 'br'],

--- a/src/test/php/webservices/rest/unittest/CookiesTest.class.php
+++ b/src/test/php/webservices/rest/unittest/CookiesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace webservices\rest\unittest;
 
 use lang\ElementNotFoundException;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use webservices\rest\{Cookie, Cookies};
 
 class CookiesTest {

--- a/src/test/php/webservices/rest/unittest/EndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/EndpointTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\{Error, FormatException, IllegalArgumentException};
 use peer\URL;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\URI;
 use webservices\rest\{Endpoint, RestResource};
 

--- a/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
+++ b/src/test/php/webservices/rest/unittest/ExecuteTest.class.php
@@ -4,7 +4,7 @@ use io\streams\MemoryInputStream;
 use lang\ClassLoader;
 use peer\ConnectException;
 use peer\http\{Authorization, HttpConnection, HttpRequest, HttpResponse};
-use unittest\{Assert, Expect, Test};
+use test\{Assert, Expect, Test, Values};
 use util\log\layout\PatternLayout;
 use util\log\{Appender, Logging, LoggingEvent};
 use webservices\rest\{Endpoint, RestException, RestUpload};

--- a/src/test/php/webservices/rest/unittest/FormatsTest.class.php
+++ b/src/test/php/webservices/rest/unittest/FormatsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace webservices\rest\unittest;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use webservices\rest\format\{FormUrlencoded, Format, Json, NdJson, Unsupported};
 use webservices\rest\{Formats, RestFormat};
 

--- a/src/test/php/webservices/rest/unittest/LinksTest.class.php
+++ b/src/test/php/webservices/rest/unittest/LinksTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace webservices\rest\unittest;
 
 use lang\FormatException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use webservices\rest\{Link, Links};
 
 class LinksTest {

--- a/src/test/php/webservices/rest/unittest/RestRequestTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestRequestTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace webservices\rest\unittest;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use webservices\rest\RestRequest;
 
 class RestRequestTest {

--- a/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResourceTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace webservices\rest\unittest;
 
 use lang\ElementNotFoundException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\URI;
 use webservices\rest\{Cookie, Cookies, Endpoint, RestRequest, RestResource, RestResponse};
 
@@ -41,7 +41,7 @@ class RestResourceTest {
     new RestResource($this->endpoint(), '/users/{0}', [6100]);
   }
 
-  #[Test, Expect(['class' => ElementNotFoundException::class, 'withMessage' => 'No such segment "id"'])]
+  #[Test, Expect(class: ElementNotFoundException::class, message: 'No such segment "id"')]
   public function missing_segment_raises_error() {
     new RestResource($this->endpoint(), '/users/{id}');
   }
@@ -119,7 +119,7 @@ class RestResourceTest {
     Assert::equals([(new RestRequest('GET', '/users'))->with($headers)], $endpoint->sent);
   }
 
-  #[Test, Values('cookies')]
+  #[Test, Values(from: 'cookies')]
   public function including_cookies($cookies) {
     $endpoint= $this->endpoint();
     $resource= new RestResource($endpoint, '/users');

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\MemoryInputStream;
 use lang\IllegalStateException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\URI;
 use util\data\Marshalling;
 use webservices\rest\format\{Json, Unsupported};
@@ -40,7 +40,7 @@ class RestResponseTest {
     new RestResponse(200, 'OK', ...$this->json('{}'));
   }
 
-  #[Test, Values(eval: '["http://localhost/", new URI("http://localhost/")])]')]
+  #[Test, Values(eval: '["http://localhost/", new URI("http://localhost/")]')]
   public function can_create_with_uri($uri) {
     new RestResponse(200, 'OK', [], null, $uri);
   }
@@ -162,7 +162,7 @@ class RestResponseTest {
     Assert::equals(['key' => 'value'], (new RestResponse(200, 'OK', ...$this->json('{"key":"value"}')))->value());
   }
 
-  #[Test, Expect(class: UnexpectedStatus::class, withMessage: 'Unexpected 400 (Bad Request)')]
+  #[Test, Expect(class: UnexpectedStatus::class, message: 'Unexpected 400 (Bad Request)')]
   public function value_on_error() {
     (new RestResponse(400, 'Bad Request', ...$this->json('{"message":"Error"}')))->value();
   }
@@ -237,7 +237,7 @@ class RestResponseTest {
     ]));
   }
 
-  #[Test, Expect(class: UnexpectedStatus::class, withMessage: 'Unexpected 503 (Service Unavailable)')]
+  #[Test, Expect(class: UnexpectedStatus::class, message: 'Unexpected 503 (Service Unavailable)')]
   public function match_on_unhandled() {
     (new RestResponse(503, 'Service Unavailable', ...$this->json('{"error":"Database down"}')))->match([
       200 => function($response) { return $response->value(); },

--- a/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace webservices\rest\unittest;
 
 use io\streams\MemoryInputStream;
-use unittest\{Assert, Test, Values};
-use webservices\rest\{TestEndpoint, RestResponse};
+use test\{Assert, Test, Values};
+use webservices\rest\{RestResponse, TestEndpoint};
 
 class TestEndpointTest {
 

--- a/src/test/php/webservices/rest/unittest/TimeoutTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TimeoutTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace webservices\rest\unittest;
 
 use peer\http\HttpConnection;
-use unittest\{Assert, Before, Test};
+use test\{Assert, Before, Test};
 use webservices\rest\{Endpoint, RestRequest};
 
 class TimeoutTest {

--- a/src/test/php/webservices/rest/unittest/format/FormUrlencodedTest.class.php
+++ b/src/test/php/webservices/rest/unittest/format/FormUrlencodedTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace webservices\rest\unittest\format;
 
 use io\streams\{MemoryInputStream, MemoryOutputStream};
-use unittest\Assert;
-use unittest\{Test, TestCase};
+use test\Assert;
+use test\{Test, TestCase};
 use webservices\rest\format\FormUrlencoded;
 
 class FormUrlencodedTest {

--- a/src/test/php/webservices/rest/unittest/format/JsonTest.class.php
+++ b/src/test/php/webservices/rest/unittest/format/JsonTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace webservices\rest\unittest\format;
 
 use io\streams\{MemoryInputStream, MemoryOutputStream};
-use unittest\Assert;
-use unittest\{Test, TestCase, Values};
+use test\Assert;
+use test\{Test, TestCase, Values};
 use webservices\rest\format\Json;
 
 class JsonTest {

--- a/src/test/php/webservices/rest/unittest/format/NdJsonTest.class.php
+++ b/src/test/php/webservices/rest/unittest/format/NdJsonTest.class.php
@@ -2,8 +2,8 @@
 
 use io\streams\{MemoryInputStream, MemoryOutputStream};
 use lang\XPException;
-use unittest\Assert;
-use unittest\{Test, TestCase, Values};
+use test\Assert;
+use test\{Test, TestCase, Values};
 use webservices\rest\format\NdJson;
 
 class NdJsonTest {


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Needed the following diff after automatic migration:

```diff
- #[Test, Action(eval: 'new ExtensionAvailable("brotli")')]
+ #[Test, Runtime(extensions: ['brotli'])]
```