### PR TITLE
Support "text/json" in addition to the correct "application/json"

### DIFF
--- a/src/main/php/webservices/rest/Formats.class.php
+++ b/src/main/php/webservices/rest/Formats.class.php
@@ -17,8 +17,14 @@ class Formats {
    */
   public static function defaults() {
     $self= new self();
+
+    // Various JSON variants, see https://stackoverflow.com/a/69518701
+    $json= new Json();
+    $self->matches['application/json']= $json;
+    $self->matches['text/json']= $json;
+    $self->patterns['#^application/(.+)\+json$#']= $json;
+
     $self->matches[NdJson::MIMETYPE]= new NdJson();
-    $self->patterns['#^application/(.+)\+json$#']= $self->matches['application/json']= new Json();
     $self->matches['application/x-www-form-urlencoded']= new FormUrlencoded();
     return $self;
   }

--- a/src/test/php/webservices/rest/unittest/FormatsTest.class.php
+++ b/src/test/php/webservices/rest/unittest/FormatsTest.class.php
@@ -11,9 +11,9 @@ class FormatsTest {
     new Formats();
   }
 
-  #[Test]
-  public function supports_json_by_default() {
-    Assert::instance(Json::class, Formats::defaults()->named('application/json'));
+  #[Test, Values(['application/json', 'text/json'])]
+  public function supports_json_by_default($mime) {
+    Assert::instance(Json::class, Formats::defaults()->named($mime));
   }
 
   #[Test]


### PR DESCRIPTION
...following the principle "Be liberal in what you accept".

See also https://stackoverflow.com/questions/22406077/what-is-the-exact-difference-between-content-type-text-json-and-application-jso