### PR TITLE
Add TestCall::payload() which returns marshalled payload

### DIFF
--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -18,7 +18,8 @@ use webservices\rest\io\{Buffered, Reader, Streamed, Traced, Transmission};
  * @test  webservices.rest.unittest.ExecuteTest
  */
 class Endpoint implements Traceable {
-  protected $base, $formats, $transfer, $marshalling, $connections;
+  public $marshalling;
+  protected $base, $formats, $transfer, $connections;
   private $headers= [];
   private $cat= null;
 

--- a/src/main/php/webservices/rest/TestCall.class.php
+++ b/src/main/php/webservices/rest/TestCall.class.php
@@ -18,6 +18,14 @@ class TestCall extends Transmission {
   /** Returns the request associated with this call */
   public function request(): RestRequest { return $this->request; }
 
+  /** @return var */
+  public function payload() {
+    if ($payload= $this->request->payload()) {
+      return $this->marshalling->marshal($payload->value());
+    }
+    return null;
+  }
+
   /**
    * Writes given bytes
    *

--- a/src/test/php/webservices/rest/unittest/EndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/EndpointTest.class.php
@@ -4,6 +4,7 @@ use lang\{Error, FormatException, IllegalArgumentException};
 use peer\URL;
 use test\{Assert, Expect, Test, Values};
 use util\URI;
+use util\data\Marshalling;
 use webservices\rest\{Endpoint, RestResource};
 
 class EndpointTest {
@@ -37,6 +38,11 @@ class EndpointTest {
   #[Test, Values([['http://localhost', null], ['http://localhost:8080', 8080]])]
   public function port($base, $expected) {
     Assert::equals($expected, $this->newFixture($base)->base()->port());
+  }
+
+  #[Test]
+  public function marshalling() {
+    Assert::instance(Marshalling::class, $this->newFixture()->marshalling);
   }
 
   #[Test]

--- a/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
+++ b/src/test/php/webservices/rest/unittest/TestEndpointTest.class.php
@@ -102,4 +102,18 @@ class TestEndpointTest {
     $fixture= new TestEndpoint([]);
     Assert::equals(404, $fixture->resource('/')->get()->status());
   }
+
+  #[Test]
+  public function payload() {
+    $fixture= new TestEndpoint([
+      'POST /users' => function($call) {
+        return $call->respond(201, 'Created', ['Location' => '/users/'.md5($call->payload()['name'])]);
+      }
+    ]);
+    $r= $fixture->resource('/users')->post(['name' => 'Test']);
+
+    Assert::equals(201, $r->status());
+    Assert::equals('/users/'.md5('Test'), $r->headers()['Location']);
+  }
+
 }


### PR DESCRIPTION
Example:

```php
$fixture= new TestEndpoint([
  'POST /users' => function($call) {
    $payload= $call->payload(); // ["name" => "Test"]
    return $call->respond(201, 'Created', ['Location' => '/users/'.md5($payload['name'])]);
  }
]);
$fixture->resource('/users')->post(['name' => 'Test']);
```