### PR TITLE
Add RestUpload::with($headers) and RestUpload::including($cookies)

### DIFF
--- a/src/main/php/webservices/rest/RestUpload.class.php
+++ b/src/main/php/webservices/rest/RestUpload.class.php
@@ -35,6 +35,28 @@ class RestUpload {
     return $this;
   }
 
+  /**
+   * Adds given headers
+   *
+   * @param  [:string] $headers
+   * @return self
+   */
+  public function with($headers) {
+    $this->request->add($headers);
+    return $this;
+  }
+
+  /**
+   * Includes given cookies
+   *
+   * @param  [:?string]|webservices.rest.Cookie[]|webservices.rest.Cookies $cookies
+   * @return self
+   */
+  public function including($cookies) {
+    $this->request->including($cookies);
+    return $this;
+  }
+
   /** @return webservices.rest.io.Parts */
   public function open() {
     return new Parts(self::BOUNDARY, $this->endpoint->open($this->request->with([

--- a/src/test/php/webservices/rest/unittest/RestUploadTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestUploadTest.class.php
@@ -51,6 +51,50 @@ class RestUploadTest {
   }
 
   #[Test]
+  public function with_headers() {
+    $upload= new RestUpload($this->newEndpoint(), new RestRequest('POST', '/'));
+    $upload->with(['X-Test' => 'true'])->pass('name', 'Test');
+
+    Assert::equals(
+      "POST / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "X-Test: true\r\n".
+      "Content-Type: multipart/form-data; boundary=---------------boundary1xp6132872336bc4\r\n".
+      "Transfer-Encoding: chunked\r\n".
+      "\r\n".
+      "-----------------boundary1xp6132872336bc4\r\n".
+      "Content-Disposition: form-data; name=\"name\"\r\n".
+      "\r\n".
+      "Test\r\n".
+      "-----------------boundary1xp6132872336bc4--\r\n",
+      $upload->finish()->content()
+    );
+  }
+
+  #[Test]
+  public function including_cookies() {
+    $upload= new RestUpload($this->newEndpoint(), new RestRequest('POST', '/'));
+    $upload->including(['session_id' => '1234'])->pass('name', 'Test');
+
+    Assert::equals(
+      "POST / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Content-Type: multipart/form-data; boundary=---------------boundary1xp6132872336bc4\r\n".
+      "Transfer-Encoding: chunked\r\n".
+      "Cookie: session_id=1234\r\n".
+      "\r\n".
+      "-----------------boundary1xp6132872336bc4\r\n".
+      "Content-Disposition: form-data; name=\"name\"\r\n".
+      "\r\n".
+      "Test\r\n".
+      "-----------------boundary1xp6132872336bc4--\r\n",
+      $upload->finish()->content()
+    );
+  }
+
+  #[Test]
   public function transfer_file() {
     $upload= new RestUpload($this->newEndpoint(), new RestRequest('POST', '/'));
     $upload->transfer('file', new MemoryInputStream('Test'), 'test.txt');


### PR DESCRIPTION
Consisten with `RestRequest::with($headers)` and `RestRequest::inluding($cookies)`.

```php
use io\File;
use webservices\rest\Endpoint;

$file= new File($reference);

$endpoint= new Endpoint('https://api.example.com/v1');
$response= $endpoint->resource('images/edits')
  ->upload(method: 'POST')
  ->with(['X-Request-ID' => $requestId])
  ->including(['session_id' => $sessionId])
  ->transfer('images[]', $file->in(), $file->filename)
  ->pass('prompt', 'This image but all people are Simpsons characters')
  ->finish()
;
```